### PR TITLE
chore(web_search): export public API from package __init__.py

### DIFF
--- a/src/sri/web_search/__init__.py
+++ b/src/sri/web_search/__init__.py
@@ -1,0 +1,13 @@
+"""Web search package — public API exports."""
+
+from sri.web_search.checker import SufficiencyChecker
+from sri.web_search.indexer import WebResultIndexer
+from sri.web_search.pipeline import WebSearchPipeline
+from sri.web_search.searcher import WebSearcher
+
+__all__ = [
+    "SufficiencyChecker",
+    "WebResultIndexer",
+    "WebSearchPipeline",
+    "WebSearcher",
+]


### PR DESCRIPTION
Allows teammates to import directly from `sri.web_search`:

```python
from sri.web_search import WebSearchPipeline, SufficiencyChecker
```

Instead of from submodules.