### PR TITLE
feat(crawler): add LobstersSpider for secondary data source

### DIFF
--- a/src/sri/crawler/__main__.py
+++ b/src/sri/crawler/__main__.py
@@ -12,6 +12,7 @@ import sys
 from sri.crawler.pipeline import JsonPipeline
 from sri.crawler.spiders.devto import DevToSpider
 from sri.crawler.spiders.hackernews import HackerNewsSpider
+from sri.crawler.spiders.lobsters import LobstersSpider
 from sri.crawler.spiders.realpython import RealPythonSpider
 
 
@@ -37,6 +38,7 @@ def main() -> int:
         DevToSpider(max_articles=args.max_articles),
         HackerNewsSpider(max_articles=args.max_articles),
         RealPythonSpider(max_articles=args.max_articles),
+        LobstersSpider(max_articles=args.max_articles),
     ]
     pipeline = JsonPipeline(output_directory="data/raw")
     try:

--- a/src/sri/crawler/spiders/lobsters.py
+++ b/src/sri/crawler/spiders/lobsters.py
@@ -1,0 +1,108 @@
+"""Lobste.rs spider — fetches technology articles from the Lobste.rs community API.
+
+This module contains the LobstersSpider class that retrieves articles
+from Lobste.rs using their free public JSON API, requiring no authentication.
+
+API reference: https://lobste.rs/hottest.json
+"""
+
+# Standard library
+import uuid
+
+# Third-party
+from bs4 import BeautifulSoup
+
+# Local
+from sri.crawler.base import ApiSpider
+from sri.crawler.items import ArticleItem
+
+
+class LobstersSpider(ApiSpider):
+    """Fetches technology articles from the Lobste.rs public API.
+
+    Retrieves articles page by page using Lobste.rs's free JSON API,
+    requiring no authentication or API key.
+
+    Attributes:
+        max_articles: Maximum number of articles to fetch in total.
+    """
+
+    def __init__(self, max_articles: int = 500) -> None:
+        """Initialise the spider with fetch limits.
+
+        Args:
+            max_articles: Maximum number of articles to fetch in total.
+        """
+        super().__init__(max_articles)
+
+    def _search_terms(self) -> list[str]:
+        """Return a placeholder search term to trigger a single crawl loop.
+
+        Lobste.rs does not filter by tag — articles are fetched by popularity.
+        A single empty string is returned to run the pagination loop once.
+
+        Returns:
+            List with a single empty string.
+        """
+        return [""]
+
+    def _fetch_page(self, term: str, page: int) -> list[dict]:
+        """Fetch a single page of articles from the Lobste.rs API.
+
+        Lobste.rs does not support filtering by topic tag. The ``term``
+        parameter is accepted only to match the shared spider interface
+        used by ApiSpider.
+
+        Args:
+            term: Unused placeholder search term.
+            page: The page number to fetch (1-based).
+
+        Returns:
+            List of raw article dicts from the API, or empty list on error.
+        """
+
+        if page == 1:
+            url = "https://lobste.rs/hottest.json"
+        else:
+            url = f"https://lobste.rs/hottest/page/{page}.json"
+
+        result = self._get_json(url)
+
+        if not isinstance(result, list):
+            return []
+
+        return result
+
+    def _build_item(self, raw_article: dict) -> ArticleItem | None:
+        """Translate a raw Lobste.rs article dict into an ArticleItem.
+
+        The Lobste.rs API only returns metadata and external URLs. This method
+        visits the linked external article page to extract the full text content
+        required for LSI analysis.
+
+        Args:
+            raw_article: Raw article dictionary from the Lobste.rs API.
+
+        Returns:
+            Populated ArticleItem with all seven fields, or None if the
+            external article content cannot be retrieved.
+        """
+
+        article = ArticleItem()
+        article["id"] = str(uuid.uuid4())
+        article["title"] = raw_article.get("title", "")
+        article["url"] = raw_article.get("url", "")
+        article["date"] = raw_article.get("created_at", "")
+        article["source"] = "lobsters"
+        article["tags"] = raw_article.get("tags", [])
+
+        try:
+            response = self._client.get(article["url"])
+            soup = BeautifulSoup(response.text, "html.parser")
+            paragraphs = soup.find_all("p")
+            article["content"] = " ".join(p.get_text(strip=True) for p in paragraphs)
+        except Exception as error:
+            print(f"[LobstersSpider] Failed to scrape {article['url']}: {error}")
+            return None
+
+        return article

--- a/tests/sri/crawler/test_lobsters.py
+++ b/tests/sri/crawler/test_lobsters.py
@@ -1,0 +1,108 @@
+"""Tests for the LobstersSpider class.
+
+Verifies that the Lobste.rs spider correctly fetches articles,
+handles HTTP errors gracefully, and builds ArticleItems properly.
+
+All HTTP and external page requests are mocked to avoid real network calls.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+
+from sri.crawler.spiders.lobsters import LobstersSpider
+
+
+def test_fetch_page_returns_articles_on_success():
+    """_fetch_page should return articles when API request succeeds."""
+    # Arrange
+    spider = LobstersSpider()
+    mock_response = [
+        {
+            "short_id": "abc123",
+            "title": "Test Article",
+            "url": "https://example.com/article",
+            "created_at": "2026-05-20T15:29:05.000-05:00",
+            "tags": ["python", "web"],
+        }
+    ]
+    spider._get_json = MagicMock(return_value=mock_response)
+    # Act
+    result = spider._fetch_page("", 1)
+    # Assert
+    assert result == mock_response
+
+
+def test_fetch_page_returns_empty_list_on_error():
+    """_fetch_page should return an empty list when API returns None."""
+
+    # Arrange
+    spider = LobstersSpider()
+
+    spider._get_json = MagicMock(return_value=None)
+
+    # Act
+    result = spider._fetch_page("", 1)
+
+    # Assert
+    assert result == []
+
+
+def test_build_item_returns_article_item_on_success():
+    """_build_item should return an ArticleItem when article data and scraping succeed."""
+
+    # Arrange
+    spider = LobstersSpider()
+
+    raw_article = {
+        "short_id": "e7lsqn",
+        "title": "Test Article",
+        "url": "https://example.com/article",
+        "created_at": "2026-05-20T15:29:05.000-05:00",
+        "tags": ["browsers", "security"],
+    }
+
+    html = """
+    <html>
+        <body>
+            <p>First paragraph.</p>
+            <p>Second paragraph.</p>
+        </body>
+    </html>
+    """
+
+    spider._client.get = MagicMock(return_value=MagicMock(text=html))
+
+    # Act
+    result = spider._build_item(raw_article)
+
+    # Assert
+    assert result is not None
+    assert result["title"] == "Test Article"
+    assert result["url"] == "https://example.com/article"
+    assert result["source"] == "lobsters"
+    assert "First paragraph." in result["content"]
+    assert "Second paragraph." in result["content"]
+
+
+def test_build_item_returns_none_on_scraping_error():
+    """_build_item should return None when external page request fails."""
+
+    # Arrange
+    spider = LobstersSpider()
+
+    raw_article = {
+        "short_id": "e7lsqn",
+        "title": "Test Article",
+        "url": "https://example.com/article",
+        "created_at": "2026-05-20T15:29:05.000-05:00",
+        "tags": ["browsers", "security"],
+    }
+
+    spider._client.get = MagicMock(side_effect=httpx.HTTPError("Network error"))
+
+    # Act
+    result = spider._build_item(raw_article)
+
+    # Assert
+    assert result is None


### PR DESCRIPTION
## Summary
Add LobstersSpider that fetches articles from the Lobste.rs JSON API and scrapes full content from external URLs using BeautifulSoup.

## Changes
- Add `LobstersSpider` inheriting from `ApiSpider`
- Fetches article list from `lobste.rs/hottest.json` with pagination
- Scrapes full content from each article's external URL
- Maps fields to team contract (id, title, content, url, source, date, tags)
- Register spider in crawler entry point
- 4 tests passing

Closes #10