### PR TITLE
feat(crawler): add TheNewStackSpider for RSS feed source

### DIFF
--- a/src/sri/crawler/__main__.py
+++ b/src/sri/crawler/__main__.py
@@ -14,6 +14,7 @@ from sri.crawler.spiders.devto import DevToSpider
 from sri.crawler.spiders.hackernews import HackerNewsSpider
 from sri.crawler.spiders.lobsters import LobstersSpider
 from sri.crawler.spiders.realpython import RealPythonSpider
+from sri.crawler.spiders.thenewstack import TheNewStackSpider
 
 
 def main() -> int:
@@ -39,6 +40,7 @@ def main() -> int:
         HackerNewsSpider(max_articles=args.max_articles),
         RealPythonSpider(max_articles=args.max_articles),
         LobstersSpider(max_articles=args.max_articles),
+        TheNewStackSpider(max_articles=args.max_articles),
     ]
     pipeline = JsonPipeline(output_directory="data/raw")
     try:

--- a/src/sri/crawler/spiders/thenewstack.py
+++ b/src/sri/crawler/spiders/thenewstack.py
@@ -1,0 +1,133 @@
+"""The New Stack spider — fetches technology articles from The New Stack RSS feed.
+
+This module contains the TheNewStackSpider class that retrieves articles
+from https://thenewstack.io/feed/ using their public RSS feed (XML),
+requiring no authentication or API key.
+
+The feed provides structured metadata and article links, which are later
+processed to extract full content for indexing in the SRI pipeline.
+"""
+
+# Standard library
+import uuid
+
+# Third-party
+import httpx
+from bs4 import BeautifulSoup
+
+# Local
+from sri.crawler.base import BaseSpider
+from sri.crawler.items import ArticleItem
+
+
+class TheNewStackSpider(BaseSpider):
+    """Fetches technology articles from The New Stack RSS feed.
+
+    Parses the RSS feed at https://thenewstack.io/feed/ and extracts
+    article metadata and full content directly from the XML fields
+    (including content:encoded). No additional HTTP requests to article
+    pages are required.
+
+    The feed already contains complete article bodies, so this spider
+    operates as a single-pass XML parser.
+    """
+
+    def __init__(self, max_articles: int = 500) -> None:
+        """Initialise the spider with fetch limits.
+
+        Args:
+            max_articles: Maximum number of articles to fetch in total.
+        """
+        super().__init__(max_articles)
+        self._client = httpx.Client(timeout=10.0)
+
+    def fetch_articles(self) -> list[ArticleItem]:
+        """Fetch and parse articles from The New Stack RSS feed.
+
+        This method performs a single HTTP request to the RSS endpoint,
+        parses the XML response using BeautifulSoup, iterates over all
+        <item> entries, and extracts:
+
+        - title
+        - link
+        - publication date
+        - tags/categories
+        - full article content from content:encoded
+
+        Each item is converted into an ArticleItem until max_articles is
+        reached. No additional page crawling is required since the RSS
+        feed contains complete article content.
+
+        Returns:
+            List of ArticleItem objects ready for indexing.
+        """
+
+        collected: list[ArticleItem] = []
+
+        response = self._client.get("https://thenewstack.io/feed/")
+        soup = BeautifulSoup(response.text, "xml")
+
+        items = soup.find_all("item")
+
+        for raw_item in items:
+            if len(collected) >= self.max_articles:
+                break
+
+            item = self._build_item(raw_item)
+            if item is not None:
+                collected.append(item)
+
+        return collected
+
+    def _build_item(self, raw_item: "BeautifulSoup") -> ArticleItem | None:
+        """Convert a <item> from The New Stack RSS feed into an ArticleItem.
+
+        Extracts metadata and full article content from the XML structure:
+
+        - title: from <title>
+        - url: from <link>
+        - date: from <pubDate>
+        - tags: from multiple <category> fields
+        - content: from <content:encoded> (parsed as HTML)
+
+        The <content:encoded> field contains HTML wrapped in CDATA.
+        This method parses that HTML using BeautifulSoup and extracts only
+        the visible text from <p> tags.
+
+        Args:
+            raw_item: BeautifulSoup element representing an RSS <item>.
+
+        Returns:
+            ArticleItem populated with extracted fields, or None if
+            required fields are missing.
+        """
+
+        title_tag = raw_item.find("title")
+        link_tag = raw_item.find("link")
+        date_tag = raw_item.find("pubDate")
+
+        content_tag = raw_item.find("encoded")
+
+        if not title_tag or not link_tag or not date_tag or not content_tag:
+            return None
+
+        categories = raw_item.find_all("category")
+        tags = [c.get_text(strip=True) for c in categories]
+
+        html_content = content_tag.get_text()
+
+        content_soup = BeautifulSoup(html_content, "html.parser")
+        paragraphs = content_soup.find_all("p")
+        content = "\n".join(p.get_text(strip=True) for p in paragraphs)
+
+        article = ArticleItem()
+
+        article["id"] = str(uuid.uuid4())
+        article["title"] = title_tag.get_text(strip=True)
+        article["url"] = link_tag.get_text(strip=True)
+        article["date"] = date_tag.get_text(strip=True)
+        article["tags"] = tags
+        article["content"] = content
+        article["source"] = "thenewstack"
+
+        return article

--- a/tests/sri/crawler/test_thenewstack.py
+++ b/tests/sri/crawler/test_thenewstack.py
@@ -1,0 +1,117 @@
+"""Tests for the TheNewStackSpider class.
+
+Verifies that the The New Stack spider correctly parses RSS XML feeds,
+builds ArticleItems from <item> entries, and handles missing or invalid
+XML fields gracefully.
+
+All HTTP calls are mocked to avoid real network requests.
+"""
+
+from unittest.mock import MagicMock
+
+from bs4 import BeautifulSoup
+
+from sri.crawler.spiders.thenewstack import TheNewStackSpider
+
+
+def test_build_item_returns_article_item_on_valid_xml():
+    """_build_item should return an ArticleItem when XML item is valid."""
+
+    # Arrange
+    spider = TheNewStackSpider()
+
+    xml = """
+    <item>
+        <title>Test Article</title>
+        <link>https://example.com/article</link>
+        <pubDate>Wed, 20 May 2026 21:11:28 +0000</pubDate>
+        <category>AI</category>
+        <category>Web</category>
+        <content:encoded><![CDATA[
+            <p>First paragraph.</p>
+            <p>Second paragraph.</p>
+        ]]></content:encoded>
+    </item>
+    """
+
+    raw_item = BeautifulSoup(xml, "xml").find("item")
+
+    # Act
+    result = spider._build_item(raw_item)
+
+    # Assert
+    assert result is not None
+    assert result["title"] == "Test Article"
+    assert result["url"] == "https://example.com/article"
+    assert result["source"] == "thenewstack"
+    assert "First paragraph." in result["content"]
+    assert "Second paragraph." in result["content"]
+    assert "AI" in result["tags"]
+    assert "Web" in result["tags"]
+
+
+def test_build_item_returns_none_when_fields_missing():
+    """_build_item should return None when required XML fields are missing."""
+
+    # Arrange
+    spider = TheNewStackSpider()
+
+    xml = """
+    <item>
+        <title>Test Article</title>
+        <link>https://example.com/article</link>
+        <pubDate>Wed, 20 May 2026 21:11:28 +0000</pubDate>
+        <category>AI</category>
+    </item>
+    """
+
+    raw_item = BeautifulSoup(xml, "xml").find("item")
+
+    # Act
+    result = spider._build_item(raw_item)
+
+    # Assert
+    assert result is None
+
+
+def test_fetch_articles_returns_articles_on_success():
+    """fetch_articles should return ArticleItems when RSS feed is valid."""
+
+    # Arrange
+    spider = TheNewStackSpider(max_articles=2)
+
+    rss_xml = """
+    <rss>
+        <channel>
+            <item>
+                <title>Article 1</title>
+                <link>https://example.com/1</link>
+                <pubDate>Wed, 20 May 2026 21:11:28 +0000</pubDate>
+                <category>AI</category>
+                <content:encoded><![CDATA[
+                    <p>Content 1</p>
+                ]]></content:encoded>
+            </item>
+            <item>
+                <title>Article 2</title>
+                <link>https://example.com/2</link>
+                <pubDate>Wed, 20 May 2026 21:11:28 +0000</pubDate>
+                <category>Web</category>
+                <content:encoded><![CDATA[
+                    <p>Content 2</p>
+                ]]></content:encoded>
+            </item>
+        </channel>
+    </rss>
+    """
+
+    spider._client.get = MagicMock(return_value=MagicMock(text=rss_xml))
+
+    # Act
+    result = spider.fetch_articles()
+
+    # Assert
+    assert len(result) == 2
+    assert result[0]["title"] == "Article 1"
+    assert result[1]["title"] == "Article 2"
+    assert result[0]["source"] == "thenewstack"


### PR DESCRIPTION
## Summary
Add TheNewStackSpider that fetches articles from The New Stack RSS feed. Content is extracted directly from the content:encoded XML field — no external page requests needed.

## Changes
- Add `TheNewStackSpider` inheriting from `BaseSpider`
- Fetches and parses RSS feed from thenewstack.io/feed/
- Extracts full content from content:encoded field
- Maps fields to team contract (id, title, content, url, source, date, tags)
- Register spider in crawler entry point
- 3 tests passing

Closes #12