### PR TITLE
feat(crawler): add TheVergeSpider for Atom feed source

### DIFF
--- a/src/sri/crawler/__main__.py
+++ b/src/sri/crawler/__main__.py
@@ -15,6 +15,7 @@ from sri.crawler.spiders.hackernews import HackerNewsSpider
 from sri.crawler.spiders.lobsters import LobstersSpider
 from sri.crawler.spiders.realpython import RealPythonSpider
 from sri.crawler.spiders.thenewstack import TheNewStackSpider
+from sri.crawler.spiders.theverge import TheVergeSpider
 
 
 def main() -> int:
@@ -41,6 +42,7 @@ def main() -> int:
         RealPythonSpider(max_articles=args.max_articles),
         LobstersSpider(max_articles=args.max_articles),
         TheNewStackSpider(max_articles=args.max_articles),
+        TheVergeSpider(max_articles=args.max_articles),
     ]
     pipeline = JsonPipeline(output_directory="data/raw")
     try:

--- a/src/sri/crawler/spiders/theverge.py
+++ b/src/sri/crawler/spiders/theverge.py
@@ -1,0 +1,131 @@
+"""The Verge spider — fetches technology articles from The Verge RSS/Atom feed.
+
+This module contains the TheVergeSpider class that retrieves articles
+from The Verge feed using Atom XML parsing, requiring no authentication
+or API key.
+
+The feed provides structured metadata (<entry> nodes) and full article
+content, which is extracted and transformed into ArticleItem objects for
+the SRI pipeline.
+"""
+
+# Standard library
+import uuid
+
+# Third-party
+import httpx
+from bs4 import BeautifulSoup
+
+# Local
+from sri.crawler.base import BaseSpider
+from sri.crawler.items import ArticleItem
+
+
+class TheVergeSpider(BaseSpider):
+    """Fetches technology articles from The Verge Atom feed.
+
+    Parses the Atom feed and extracts article metadata and full content
+    directly from <entry> nodes. No additional crawling is required since
+    the feed contains complete article bodies.
+
+    Attributes:
+        max_articles: Maximum number of articles to fetch in total.
+    """
+
+    def __init__(self, max_articles: int = 500) -> None:
+        """Initialise the spider with fetch limits.
+
+        Args:
+            max_articles: Maximum number of articles to fetch in total.
+        """
+        super().__init__(max_articles)
+        self._client = httpx.Client(timeout=10.0)
+
+    def fetch_articles(self) -> list[ArticleItem]:
+        """Fetch and parse articles from The Verge Atom feed.
+
+        This method performs a single HTTP request to the Atom feed,
+        parses the XML response using BeautifulSoup, iterates over all
+        <entry> nodes, and extracts:
+
+        - title
+        - url (from link[@rel="alternate"])
+        - publication date
+        - tags/categories
+        - full article content from <content>
+
+        Each entry is converted into an ArticleItem until max_articles is
+        reached. No additional page crawling is required.
+
+        Returns:
+            List of ArticleItem objects ready for indexing.
+        """
+
+        collected: list[ArticleItem] = []
+
+        response = self._client.get("https://www.theverge.com/rss/index.xml")
+        soup = BeautifulSoup(response.text, "xml")
+
+        entries = soup.find_all("entry")
+
+        for entry in entries:
+            if len(collected) >= self.max_articles:
+                break
+
+            item = self._build_item(entry)
+            if item is not None:
+                collected.append(item)
+
+        return collected
+
+    def _build_item(self, entry: "BeautifulSoup") -> ArticleItem | None:
+        """Convert an Atom <entry> from The Verge feed into an ArticleItem.
+
+        Extracts and transforms structured data from the Atom XML entry:
+
+        - title: from <title>
+        - url: from <link rel="alternate"> (href attribute)
+        - date: from <published>
+        - tags: from all <category term="..."> attributes
+        - content: from <content> (HTML body parsed into plain text)
+
+        The <content> field contains HTML markup which is parsed using
+        BeautifulSoup to extract only readable paragraph text.
+
+        Args:
+            entry: BeautifulSoup element representing an Atom <entry> node.
+
+        Returns:
+            ArticleItem populated with extracted fields, or None if
+            required fields are missing.
+        """
+
+        title_tag = entry.find("title")
+        date_tag = entry.find("published")
+        content_tag = entry.find("content")
+
+        link_tag = entry.find("link", rel="alternate")
+
+        if not title_tag or not date_tag or not content_tag or not link_tag:
+            return None
+
+        categories = entry.find_all("category")
+        tags = [cat.get("term", "") for cat in categories if cat.get("term")]
+
+        html_content = content_tag.get_text()
+
+        content_soup = BeautifulSoup(html_content, "html.parser")
+        paragraphs = content_soup.find_all("p")
+        content = "\n".join(p.get_text(strip=True) for p in paragraphs)
+
+        article = ArticleItem()
+
+        article["id"] = str(uuid.uuid4())
+        article["title"] = title_tag.get_text(strip=True)
+        article["url"] = link_tag.get("href", "")
+        article["date"] = date_tag.get_text(strip=True)
+        article["tags"] = tags
+        article["content"] = content
+        article["source"] = "theverge"
+
+        return article

--- a/tests/sri/crawler/test_theverge.py
+++ b/tests/sri/crawler/test_theverge.py
@@ -1,0 +1,114 @@
+"""Tests for the TheVergeSpider class.
+
+Verifies that The Verge spider correctly parses Atom XML feeds,
+builds ArticleItems from <entry> nodes, and handles missing or invalid
+XML fields gracefully.
+
+All HTTP calls are mocked to avoid real network requests.
+"""
+
+from unittest.mock import MagicMock
+
+from bs4 import BeautifulSoup
+
+from sri.crawler.spiders.theverge import TheVergeSpider
+
+
+def test_build_item_returns_article_item_on_valid_xml():
+    """_build_item should return an ArticleItem when Atom entry is valid."""
+
+    # Arrange
+    spider = TheVergeSpider()
+
+    xml = """
+    <entry>
+        <title>Test Article</title>
+        <link rel="alternate" href="https://example.com/article" />
+        <published>2026-05-20T21:11:28Z</published>
+        <category term="AI" />
+        <category term="Web" />
+        <content><![CDATA[
+            <p>First paragraph.</p>
+            <p>Second paragraph.</p>
+        ]]></content>
+    </entry>
+    """
+
+    entry = BeautifulSoup(xml, "xml").find("entry")
+
+    # Act
+    result = spider._build_item(entry)
+
+    # Assert
+    assert result is not None
+    assert result["title"] == "Test Article"
+    assert result["url"] == "https://example.com/article"
+    assert result["source"] == "theverge"
+    assert "First paragraph." in result["content"]
+    assert "Second paragraph." in result["content"]
+    assert "AI" in result["tags"]
+    assert "Web" in result["tags"]
+
+
+def test_build_item_returns_none_when_fields_missing():
+    """_build_item should return None when required XML fields are missing."""
+
+    # Arrange
+    spider = TheVergeSpider()
+
+    xml = """
+    <entry>
+        <title>Test Article</title>
+        <published>2026-05-20T21:11:28Z</published>
+        <category term="AI" />
+    </entry>
+    """
+
+    entry = BeautifulSoup(xml, "xml").find("entry")
+
+    # Act
+    result = spider._build_item(entry)
+
+    # Assert
+    assert result is None
+
+
+def test_fetch_articles_returns_articles_on_success():
+    """fetch_articles should return ArticleItems when Atom feed is valid."""
+
+    # Arrange
+    spider = TheVergeSpider(max_articles=2)
+
+    atom_xml = """
+    <feed>
+        <entry>
+            <title>Article 1</title>
+            <link rel="alternate" href="https://example.com/1" />
+            <published>2026-05-20T21:11:28Z</published>
+            <category term="AI" />
+            <content><![CDATA[
+                <p>Content 1</p>
+            ]]></content>
+        </entry>
+        <entry>
+            <title>Article 2</title>
+            <link rel="alternate" href="https://example.com/2" />
+            <published>2026-05-20T21:11:28Z</published>
+            <category term="Web" />
+            <content><![CDATA[
+                <p>Content 2</p>
+            ]]></content>
+        </entry>
+    </feed>
+    """
+
+    spider._client.get = MagicMock(return_value=MagicMock(text=atom_xml))
+
+    # Act
+    result = spider.fetch_articles()
+
+    # Assert
+    assert len(result) == 2
+    assert result[0]["title"] == "Article 1"
+    assert result[1]["title"] == "Article 2"
+    assert result[0]["source"] == "theverge"


### PR DESCRIPTION
## Summary
Add TheVergeSpider that fetches articles from The Verge Atom feed. Content is extracted directly from the <content> XML field.

## Changes
- Add `TheVergeSpider` inheriting from `BaseSpider`
- Fetches and parses Atom feed from theverge.com/rss/index.xml
- Extracts full content from <content> field
- Maps fields to team contract (id, title, content, url, source, date, tags)
- Register spider in crawler entry point
- 3 tests passing

Closes #14