### PR TITLE
Fix broken imports in src/sri/pipeline.py

### DIFF
--- a/src/sri/pipeline.py
+++ b/src/sri/pipeline.py
@@ -16,17 +16,14 @@ Uso rápido:
 """
 
 import os
-import json
-from typing import List, Dict, Optional
 
-from modules.indexer import InvertedIndex
-from modules.lsi_model import LSIModel
-from modules.vector_store import VectorStore, _CHROMA_AVAILABLE
-from modules.ranking import RankingEngine
-from modules.evaluation import Evaluator
+from evaluation.evaluation import Evaluator
+from indexing.indexer import InvertedIndex
+from ranking.ranking import RankingEngine
+from retrieval.lsi_model import LSIModel
+from retrieval.vector_store import _CHROMA_AVAILABLE, VectorStore
 
-
-DATA_DIR  = "data"
+DATA_DIR = "data"
 INDEX_DIR = os.path.join(DATA_DIR, "index")
 MODEL_DIR = os.path.join(DATA_DIR, "models")
 
@@ -55,16 +52,16 @@ class SRIPipeline:
 
         # Módulos
         self.indexer = InvertedIndex(use_stemming=True)
-        self.lsi     = LSIModel(n_components=lsi_components)
+        self.lsi = LSIModel(n_components=lsi_components)
 
         # VectorStore: usa ChromaDB si está instalado, backend propio si no
         self.vstore = VectorStore(
             collection_name="tech_software",
             persist_dir=INDEX_DIR,
-            use_chromadb=_CHROMA_AVAILABLE,   # ← automático, no requiere cambio manual
+            use_chromadb=_CHROMA_AVAILABLE,  # ← automático, no requiere cambio manual
         )
 
-        self.ranker    = RankingEngine()
+        self.ranker = RankingEngine()
         self.evaluator = Evaluator(k_values=[1, 3, 5, 10])
 
         if load_existing:
@@ -74,7 +71,7 @@ class SRIPipeline:
     # Indexación
     # ------------------------------------------------------------------
 
-    def index(self, documents: List[Dict], save: bool = True) -> None:
+    def index(self, documents: list[dict], save: bool = True) -> None:
         """
         Indexa una lista de documentos en todos los módulos.
 
@@ -98,10 +95,12 @@ class SRIPipeline:
 
         # Estadísticas
         stats = self.indexer.stats()
-        print(f"[Pipeline] Vocabulario: {stats['vocab_size']} términos | "
-              f"Longitud media doc: {stats['avg_doc_len']:.0f} tokens")
+        print(
+            f"[Pipeline] Vocabulario: {stats['vocab_size']} términos | "
+            f"Longitud media doc: {stats['avg_doc_len']:.0f} tokens"
+        )
 
-    def add_document(self, doc: Dict) -> None:
+    def add_document(self, doc: dict) -> None:
         """Agrega un documento al sistema sin reentrenar LSI."""
         self.indexer.add_document(doc)
         self.vstore.add([doc])
@@ -114,10 +113,10 @@ class SRIPipeline:
     def search(
         self,
         query: str,
-        top_k: Optional[int] = None,
+        top_k: int | None = None,
         use_lsi: bool = True,
         use_vector: bool = True,
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """
         Recupera y rankea documentos para una consulta.
 
@@ -139,12 +138,12 @@ class SRIPipeline:
             sorted_ids = sorted(scores, key=scores.get, reverse=True)[: k * 2]
             lsi_results = [
                 {
-                    "doc_id":  did,
-                    "score":   scores[did] / 10,
-                    "title":   self.indexer.doc_metadata.get(did, {}).get("title", ""),
+                    "doc_id": did,
+                    "score": scores[did] / 10,
+                    "title": self.indexer.doc_metadata.get(did, {}).get("title", ""),
                     "snippet": "",
-                    "url":     self.indexer.doc_metadata.get(did, {}).get("url", ""),
-                    "tags":    [],
+                    "url": self.indexer.doc_metadata.get(did, {}).get("url", ""),
+                    "tags": [],
                 }
                 for did in sorted_ids
             ]
@@ -161,7 +160,7 @@ class SRIPipeline:
 
         return self.ranker.assign_positions(ranked)
 
-    def search_ids(self, query: str, top_k: Optional[int] = None) -> List[str]:
+    def search_ids(self, query: str, top_k: int | None = None) -> list[str]:
         """Versión simplificada que devuelve solo IDs (para evaluación)."""
         results = self.search(query, top_k=top_k)
         return [r["doc_id"] for r in results]
@@ -173,8 +172,8 @@ class SRIPipeline:
     def evaluate(
         self,
         test_queries_path: str,
-        output_path: Optional[str] = None,
-    ) -> Dict:
+        output_path: str | None = None,
+    ) -> dict:
         """Evalúa el sistema con un archivo de consultas de prueba."""
         test_queries = Evaluator.load_test_queries(test_queries_path)
         results = self.evaluator.evaluate_all(


### PR DESCRIPTION
## What this PR does
Fixes `ModuleNotFoundError: No module named 'modules'` introduced in PR #20.

## Root cause
PR #20 changed imports in `src/sri/pipeline.py` to reference a non-existent `modules.*` package.

## Fix
Replaced all 5 broken imports with the correct paths matching the actual project structure.

## Verification
```
PYTHONPATH=src python -c "from sri.pipeline import SRIPipeline; print('OK')"
```
Output: `OK`

Closes #22