### PR TITLE
Fix WebSearcher to fetch full article content from URLs

### DIFF
--- a/src/sri/web_search/searcher.py
+++ b/src/sri/web_search/searcher.py
@@ -1,5 +1,4 @@
 """Web search module using DuckDuckGo.
-
 This module provides a simple interface to perform web searches using
 DuckDuckGo and transform the results into a standardized article format.
 """
@@ -9,62 +8,94 @@ import uuid
 from datetime import datetime, timezone
 
 # Third-party
+import httpx
+from bs4 import BeautifulSoup
 from duckduckgo_search import DDGS
 
 
 class WebSearcher:
-    """Searches the web using DuckDuckGo and returns normalized article data."""
+    """Search the web and return normalized article data."""
 
     def __init__(self, max_results: int = 10) -> None:
-        """Initializes the searcher with a maximum number of results.
+        """Initialize the searcher.
 
         Args:
-            max_results (int, optional): Maximum number of search results
-                to retrieve. Defaults to 10.
+            max_results:
+                Maximum number of search results to retrieve.
         """
         self.max_results = max_results
 
     def search(self, query: str) -> list[dict]:
-        """Performs a web search and returns normalized article results.
+        """Perform a web search and return normalized article results.
 
         Args:
-            query (str): Search query string.
+            query:
+                Search query string.
 
         Returns:
-            list[dict]: A list of articles in the standardized format.
+            A list of normalized article dictionaries.
         """
         results: list[dict] = []
-
         with DDGS() as ddgs:
-            raw_results = ddgs.text(query, max_results=self.max_results)
-
+            raw_results = ddgs.text(
+                query,
+                max_results=self.max_results,
+            )
             for raw in raw_results:
                 article = self._build_article(raw)
                 if article:
                     results.append(article)
-
         return results
 
-    def _build_article(self, raw: dict) -> dict | None:
-        """Converts a raw DuckDuckGo result into the article contract format.
+    def _fetch_full(self, url: str) -> str:
+        """Fetch and extract full article content from a webpage.
 
         Args:
-            raw (dict): Raw result from DuckDuckGo.
+            url:
+                URL of the article page.
 
         Returns:
-            dict: Normalized article dictionary with required fields.
+            Extracted article text, or an empty string if fetching fails.
+        """
+        try:
+            response = httpx.get(
+                url,
+                timeout=10.0,
+                follow_redirects=True,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError:
+            return ""
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        paragraphs = soup.find_all("p")
+        content = " ".join(paragraph.get_text(strip=True) for paragraph in paragraphs)
+        return content.strip()
+
+    def _build_article(self, raw: dict) -> dict | None:
+        """Convert a DuckDuckGo result into the article contract format.
+
+        Args:
+            raw:
+                Raw result returned by DuckDuckGo.
+
+        Returns:
+            A normalized article dictionary, or None if invalid.
         """
         title = raw.get("title")
         url = raw.get("href")
-        content = raw.get("body")
 
         if not title or not url:
+            return None
+
+        content = self._fetch_full(url)
+        if not content:
             return None
 
         return {
             "id": str(uuid.uuid4()),
             "title": title,
-            "content": content or "",
+            "content": content,
             "url": url,
             "source": "web",
             "date": datetime.now(timezone.utc).isoformat(),

--- a/tests/sri/web_search/test_searcher.py
+++ b/tests/sri/web_search/test_searcher.py
@@ -14,6 +14,7 @@ from sri.web_search.searcher import WebSearcher
 
 def test_search_returns_articles():
     """Search should return normalized articles when valid results are returned."""
+    # Arrange
     fake_results = [
         {
             "title": "Docker tutorial",
@@ -21,16 +22,22 @@ def test_search_returns_articles():
             "body": "Docker is a container tool...",
         }
     ]
-
-    with patch("sri.web_search.searcher.DDGS") as mock_ddgs:
+    with (
+        patch("sri.web_search.searcher.DDGS") as mock_ddgs,
+        patch(
+            "sri.web_search.searcher.WebSearcher._fetch_full",
+            return_value="Full Docker article content.",
+        ),
+    ):
         mock_ddgs.return_value.__enter__.return_value.text.return_value = fake_results
-
         searcher = WebSearcher()
+        # Act
         results = searcher.search("docker")
-
+    # Assert
     assert len(results) == 1
     assert results[0]["title"] == "Docker tutorial"
     assert results[0]["url"] == "https://example.com/docker"
+    assert results[0]["content"] == "Full Docker article content."
 
 
 def test_search_filters_results_without_title():
@@ -68,4 +75,33 @@ def test_search_filters_results_without_url():
         searcher = WebSearcher()
         results = searcher.search("docker")
 
+    assert len(results) == 0
+
+
+def test_search_filters_results_without_content():
+    """Search should filter out results when full content fetching fails."""
+    # Arrange
+    fake_results = [
+        {
+            "title": "Docker tutorial",
+            "href": "https://example.com/docker",
+            "body": "Docker is a container tool...",
+        }
+    ]
+
+    with (
+        patch("sri.web_search.searcher.DDGS") as mock_ddgs,
+        patch(
+            "sri.web_search.searcher.WebSearcher._fetch_full",
+            return_value="",
+        ),
+    ):
+        mock_ddgs.return_value.__enter__.return_value.text.return_value = fake_results
+
+        searcher = WebSearcher()
+
+        # Act
+        results = searcher.search("docker")
+
+    # Assert
     assert len(results) == 0


### PR DESCRIPTION
## Summary
Replace DuckDuckGo snippet with full article body by visiting each URL with httpx and extracting paragraph text via BeautifulSoup.

## Changes
- Added `_fetch_full(url)` method to `WebSearcher` that visits each URL and extracts `<p>` tag content
- Updated `_build_article` to use full content instead of DDG snippet
- Articles with empty content after fetching are discarded
- Updated and added tests to mock `_fetch_full`

## Tests
33/33 passing

Closes #24