### PR TITLE
Centralize crawler hardcoded values into CrawlerSettings

### DIFF
--- a/src/sri/crawler/settings.py
+++ b/src/sri/crawler/settings.py
@@ -1,0 +1,47 @@
+"""Centralized configuration for crawler spiders and web sources."""
+
+
+class CrawlerSettings:
+    """Shared configuration values for crawler modules.
+
+    This class centralizes HTTP settings, fetch limits, API endpoints,
+    RSS feeds, and search terms used across all crawler spiders.
+    """
+
+    # HTTP
+    HTTP_TIMEOUT: float = 10.0
+
+    # Fetch limits
+    MAX_ARTICLES: int = 500
+    PER_PAGE: int = 100
+
+    # Dev.to
+    DEVTO_API_URL: str = "https://dev.to/api/articles"
+    DEVTO_TAGS: list[str] = [
+        "python",
+        "software",
+        "programming",
+        "webdev",
+        "javascript",
+    ]
+
+    # Hacker News
+    HN_API_URL: str = "https://hn.algolia.com/api/v1/search"
+    HN_SEARCH_TERMS: list[str] = [
+        "software",
+        "python",
+        "programming",
+        "webdev",
+        "javascript",
+    ]
+
+    # Lobsters
+    LOBSTERS_BASE_URL: str = "https://lobste.rs"
+
+    # RealPython
+    REALPYTHON_BASE_URL: str = "https://realpython.com"
+    REALPYTHON_SITEMAP_URL: str = f"{REALPYTHON_BASE_URL}/sitemap.xml"
+
+    # RSS feeds
+    THE_NEW_STACK_FEED: str = "https://thenewstack.io/feed/"
+    THE_VERGE_FEED: str = "https://www.theverge.com/rss/index.xml"

--- a/src/sri/crawler/spiders/devto.py
+++ b/src/sri/crawler/spiders/devto.py
@@ -10,6 +10,7 @@ import uuid
 
 from sri.crawler.base import ApiSpider
 from sri.crawler.items import ArticleItem
+from sri.crawler.settings import CrawlerSettings
 
 
 class DevToSpider(ApiSpider):
@@ -20,21 +21,23 @@ class DevToSpider(ApiSpider):
 
     Attributes:
         max_articles: Maximum number of articles to fetch in total.
-        per_page: Number of articles to request per API call (max 100).
+        per_page: Number of articles to request per API call.
     """
 
-    def __init__(self, max_articles: int = 500, per_page: int = 100) -> None:
+    def __init__(
+        self,
+        max_articles: int = CrawlerSettings.MAX_ARTICLES,
+        per_page: int = CrawlerSettings.PER_PAGE,
+    ) -> None:
         """Initialise the spider with fetch limits.
 
         Args:
             max_articles: Maximum number of articles to fetch in total.
-            per_page: Number of articles to request per API call (max 100).
+            per_page: Number of articles to request per API call.
         """
-        super().__init__(
-            max_articles=max_articles
-        )  # Initialise the HTTP client from ApiSpider
+        super().__init__(max_articles=max_articles)
 
-        self.per_page = min(per_page, 100)  # Dev.to API max per
+        self.per_page = min(per_page, CrawlerSettings.PER_PAGE)
 
     def _fetch_page(self, tag: str, page: int) -> list[dict]:
         """Fetch a single page of articles from the Dev.to API.
@@ -47,7 +50,8 @@ class DevToSpider(ApiSpider):
             List of raw article dicts from the API, or empty list on error.
         """
 
-        url = "https://dev.to/api/articles"
+        url = CrawlerSettings.DEVTO_API_URL
+
         params = {
             "tag": tag,
             "per_page": self.per_page,
@@ -55,8 +59,10 @@ class DevToSpider(ApiSpider):
         }
 
         result = self._get_json(url, params=params)
+
         if not isinstance(result, list):
             return []
+
         return result
 
     def _fetch_full(self, article_id: int) -> dict:
@@ -73,11 +79,13 @@ class DevToSpider(ApiSpider):
             Full article dict from the API, or empty dict on error.
         """
 
-        url = f"https://dev.to/api/articles/{article_id}"
+        url = f"{CrawlerSettings.DEVTO_API_URL}/{article_id}"
 
         result = self._get_json(url)
+
         if not isinstance(result, dict):
             return {}
+
         return result
 
     def _build_item(self, raw_article: dict) -> ArticleItem | None:
@@ -95,6 +103,7 @@ class DevToSpider(ApiSpider):
         """
 
         body = self._fetch_full(raw_article["id"])
+
         if not body:
             return None
 
@@ -117,7 +126,4 @@ class DevToSpider(ApiSpider):
             List of topic tags to search for articles.
         """
 
-        # These tags cover the technology and software domain broadly
-        tags = ["python", "software", "programming", "webdev", "javascript"]
-
-        return tags
+        return CrawlerSettings.DEVTO_TAGS

--- a/src/sri/crawler/spiders/hackernews.py
+++ b/src/sri/crawler/spiders/hackernews.py
@@ -1,6 +1,8 @@
 """HackerNews spider — fetches technology articles from the Algolia public API.
+
 This module contains the HackerNewsSpider class that retrieves articles
 from Hacker News using their free public API, requiring no authentication.
+
 API reference: http://hn.algolia.com/api/v1/search?tags=story&query=software
 """
 
@@ -8,6 +10,7 @@ import uuid
 
 from sri.crawler.base import ApiSpider
 from sri.crawler.items import ArticleItem
+from sri.crawler.settings import CrawlerSettings
 
 
 class HackerNewsSpider(ApiSpider):
@@ -18,21 +21,25 @@ class HackerNewsSpider(ApiSpider):
 
     Attributes:
         max_articles: Maximum number of articles to fetch in total.
-        per_page: Number of articles to request per API call (max 100).
+        per_page: Number of articles to request per API call.
     """
 
     _start_page: int = 0  # Algolia uses 0-based pagination
 
-    def __init__(self, max_articles: int = 500, per_page: int = 100) -> None:
+    def __init__(
+        self,
+        max_articles: int = CrawlerSettings.MAX_ARTICLES,
+        per_page: int = CrawlerSettings.PER_PAGE,
+    ) -> None:
         """Initialise the spider with fetch limits.
 
         Args:
             max_articles: Maximum number of articles to fetch in total.
-            per_page: Number of articles to request per API call (max 100).
+            per_page: Number of articles to request per API call.
         """
 
         super().__init__(max_articles=max_articles)
-        self.per_page = min(per_page, 100)
+        self.per_page = min(per_page, CrawlerSettings.PER_PAGE)
 
     def _search_terms(self) -> list[str]:
         """Return Algolia search queries for the technology domain.
@@ -40,7 +47,8 @@ class HackerNewsSpider(ApiSpider):
         Returns:
             List of query strings to search for articles.
         """
-        return ["software", "python", "programming", "webdev", "javascript"]
+
+        return CrawlerSettings.HN_SEARCH_TERMS
 
     def _fetch_page(self, term: str, page: int) -> list[dict]:
         """Fetch a single page of articles from the Algolia API.
@@ -53,16 +61,18 @@ class HackerNewsSpider(ApiSpider):
             List of raw article dicts from the API, or empty list on error.
         """
 
-        url = "https://hn.algolia.com/api/v1/search"
-
         params = {
-            "tags": "story",  # only fetch stories, not comments
-            "query": term,  # the search term
-            "hitsPerPage": self.per_page,  # how many per page
-            "page": page,  # which page
+            "tags": "story",
+            "query": term,
+            "hitsPerPage": self.per_page,
+            "page": page,
         }
 
-        result = self._get_json(url, params=params)
+        result = self._get_json(
+            CrawlerSettings.HN_API_URL,
+            params=params,
+        )
+
         if not isinstance(result, dict) or "hits" not in result:
             return []
 
@@ -94,7 +104,6 @@ class HackerNewsSpider(ApiSpider):
         article["content"] = raw_article.get("story_text") or raw_article.get(
             "title", ""
         )
-
         article["source"] = "hackernews"
         article["tags"] = raw_article.get("_tags", [])
 

--- a/src/sri/crawler/spiders/lobsters.py
+++ b/src/sri/crawler/spiders/lobsters.py
@@ -15,6 +15,7 @@ from bs4 import BeautifulSoup
 # Local
 from sri.crawler.base import ApiSpider
 from sri.crawler.items import ArticleItem
+from sri.crawler.settings import CrawlerSettings
 
 
 class LobstersSpider(ApiSpider):
@@ -27,12 +28,16 @@ class LobstersSpider(ApiSpider):
         max_articles: Maximum number of articles to fetch in total.
     """
 
-    def __init__(self, max_articles: int = 500) -> None:
+    def __init__(
+        self,
+        max_articles: int = CrawlerSettings.MAX_ARTICLES,
+    ) -> None:
         """Initialise the spider with fetch limits.
 
         Args:
             max_articles: Maximum number of articles to fetch in total.
         """
+
         super().__init__(max_articles)
 
     def _search_terms(self) -> list[str]:
@@ -44,6 +49,7 @@ class LobstersSpider(ApiSpider):
         Returns:
             List with a single empty string.
         """
+
         return [""]
 
     def _fetch_page(self, term: str, page: int) -> list[dict]:
@@ -62,9 +68,9 @@ class LobstersSpider(ApiSpider):
         """
 
         if page == 1:
-            url = "https://lobste.rs/hottest.json"
+            url = f"{CrawlerSettings.LOBSTERS_BASE_URL}" "/hottest.json"
         else:
-            url = f"https://lobste.rs/hottest/page/{page}.json"
+            url = f"{CrawlerSettings.LOBSTERS_BASE_URL}" f"/hottest/page/{page}.json"
 
         result = self._get_json(url)
 
@@ -89,6 +95,7 @@ class LobstersSpider(ApiSpider):
         """
 
         article = ArticleItem()
+
         article["id"] = str(uuid.uuid4())
         article["title"] = raw_article.get("title", "")
         article["url"] = raw_article.get("url", "")
@@ -98,11 +105,15 @@ class LobstersSpider(ApiSpider):
 
         try:
             response = self._client.get(article["url"])
+
             soup = BeautifulSoup(response.text, "html.parser")
+
             paragraphs = soup.find_all("p")
+
             article["content"] = " ".join(p.get_text(strip=True) for p in paragraphs)
+
         except Exception as error:
-            print(f"[LobstersSpider] Failed to scrape {article['url']}: {error}")
+            print(f"[LobstersSpider] Failed to scrape " f"{article['url']}: {error}")
             return None
 
         return article

--- a/src/sri/crawler/spiders/realpython.py
+++ b/src/sri/crawler/spiders/realpython.py
@@ -16,126 +16,92 @@ from bs4 import BeautifulSoup
 # Local
 from sri.crawler.base import BaseSpider
 from sri.crawler.items import ArticleItem
+from sri.crawler.settings import CrawlerSettings
 
 
 class RealPythonSpider(BaseSpider):
-    """Spider that scrapes articles from the Real Python sitemap by fetching
-    and parsing HTML pages listed in the XML sitemap, instead of consuming a
-    paginated API.
+    """Spider that scrapes articles from Real Python using its sitemap.
 
-    Attributes:
-        max_articles (int): Maximum number of articles to fetch (inherited).
-        _base_url (str): Base URL of the target site.
-        _sitemap_url (str): URL of the XML sitemap containing article links.
+    This spider:
+    - Loads URLs from the XML sitemap
+    - Filters article URLs
+    - Fetches each article HTML page
+    - Extracts structured content via BeautifulSoup
     """
 
-    _base_url = "https://realpython.com"
-    _sitemap_url = "https://realpython.com/sitemap.xml"
-
     def __init__(self, max_articles: int = 500) -> None:
-        """Initializes the spider with a maximum number of articles to fetch
-        and sets up an HTTP client for making requests.
+        """Initializes HTTP client and crawl limits.
 
         Args:
-            max_articles (int, optional): Maximum number of articles to fetch.
-                Defaults to 500.
+            max_articles: Maximum number of articles to fetch.
         """
         super().__init__(max_articles)
-        self._client = httpx.Client(timeout=10.0)
+        self._client = httpx.Client(timeout=CrawlerSettings.HTTP_TIMEOUT)
+
+        self._base_url = CrawlerSettings.REALPYTHON_BASE_URL
+        self._sitemap_url = CrawlerSettings.REALPYTHON_SITEMAP_URL
 
     def fetch_articles(self) -> list[ArticleItem]:
-        """Fetches and parses articles from the Real Python sitemap.
+        """Fetch articles from Real Python sitemap and scrape content."""
 
-        This method performs a full crawling pipeline:
-
-        1. Downloads the XML sitemap from `_sitemap_url`.
-        2. Parses the sitemap to extract article URLs.
-        3. Iterates through each URL (up to `max_articles`).
-        4. Fetches each article's HTML content.
-        5. Delegates HTML parsing and item building to _build_item.
-        6. Applies rate limiting between requests to avoid overloading the server.
-
-        Error handling strategy:
-            - Network errors are retried briefly and then skipped.
-            - Parsing errors for individual articles are logged and skipped.
-            - Sitemap-level failures may stop execution if critical.
-
-        Returns:
-            list[ArticleItem]: A list of successfully parsed article items.
-
-        Notes:
-            This method is designed to be resilient to partial failures in
-            individual pages while ensuring the overall crawl completes
-            within the configured limits.
-        """
-
-        # Step 1 & 2 — fetch and parse sitemap
         response = self._client.get(self._sitemap_url)
         soup = BeautifulSoup(response.text, "xml")
-        urls = [loc.text for loc in soup.find_all("loc") if loc.text.count("/") == 4]
 
-        # Step 3 — loop with limit
+        urls = [
+            loc.text
+            for loc in soup.find_all("loc")
+            if loc.text and "/tutorials/" in loc.text
+        ]
+
         collected: list[ArticleItem] = []
 
         for url in urls:
             if len(collected) >= self.max_articles:
                 break
+
             if not self._can_fetch(url):
                 continue
+
             try:
-                # Step 4 — fetch article
                 article_response = self._client.get(url)
                 article_soup = BeautifulSoup(article_response.text, "html.parser")
 
-                # Step 5 build item
                 item = self._build_item(url, article_soup)
-                if item is not None:
+
+                if item:
                     collected.append(item)
-                # Step 6 — sleep
+
                 time.sleep(1)
+
             except Exception as error:
                 print(f"[RealPythonSpider] Failed to scrape {url}: {error}")
-                continue
 
         return collected
 
     def _build_item(self, url: str, soup: BeautifulSoup) -> ArticleItem | None:
-        """Helper method to build an ArticleItem from a BeautifulSoup object.
+        """Builds an ArticleItem from parsed HTML."""
 
-        Args:
-            url: The URL of the article being processed.
-            soup: A BeautifulSoup object containing the parsed HTML of the article.
-
-        Returns:
-          Populated ArticleItem with all seven fields, or None if the
-          article has no title.
-        """
-
-        # Extract fields from soup
-        title = soup.find("h1")
-        if not title:
+        title_tag = soup.find("h1")
+        if not title_tag:
             return None
-        title_text = title.get_text().strip()
 
-        date_span = soup.find("span", class_="text-muted")
-        date_text = date_span.get_text().strip() if date_span else ""
-
-        paragraphs = soup.find_all("p")
-        content = " ".join(p.get_text().strip() for p in paragraphs)
+        date_tag = soup.find("time")
+        content_tags = soup.find_all("p")
 
         tags = [
-            a.get_text().strip()
+            a.get_text(strip=True)
             for a in soup.find_all("a")
-            if (href := a.get("href")) and isinstance(href, str) and "/tag/" in href
+            if a.get("href") and "/tag/" in a.get("href")
         ]
 
-        # Build item
         item = ArticleItem()
+
         item["id"] = str(uuid.uuid4())
-        item["title"] = title_text
+        item["title"] = title_tag.get_text(strip=True)
         item["url"] = url
-        item["date"] = date_text
-        item["content"] = content
+        item["date"] = date_tag.get_text(strip=True) if date_tag else ""
+        item["content"] = " ".join(p.get_text(strip=True) for p in content_tags)
         item["source"] = "realpython"
         item["tags"] = tags
+
         return item

--- a/src/sri/crawler/spiders/thenewstack.py
+++ b/src/sri/crawler/spiders/thenewstack.py
@@ -18,6 +18,7 @@ from bs4 import BeautifulSoup
 # Local
 from sri.crawler.base import BaseSpider
 from sri.crawler.items import ArticleItem
+from sri.crawler.settings import CrawlerSettings
 
 
 class TheNewStackSpider(BaseSpider):
@@ -32,14 +33,21 @@ class TheNewStackSpider(BaseSpider):
     operates as a single-pass XML parser.
     """
 
-    def __init__(self, max_articles: int = 500) -> None:
+    def __init__(
+        self,
+        max_articles: int = CrawlerSettings.MAX_ARTICLES,
+    ) -> None:
         """Initialise the spider with fetch limits.
 
         Args:
             max_articles: Maximum number of articles to fetch in total.
         """
+
         super().__init__(max_articles)
-        self._client = httpx.Client(timeout=10.0)
+
+        self._client = httpx.Client(
+            timeout=CrawlerSettings.HTTP_TIMEOUT,
+        )
 
     def fetch_articles(self) -> list[ArticleItem]:
         """Fetch and parse articles from The New Stack RSS feed.
@@ -64,7 +72,10 @@ class TheNewStackSpider(BaseSpider):
 
         collected: list[ArticleItem] = []
 
-        response = self._client.get("https://thenewstack.io/feed/")
+        response = self._client.get(
+            CrawlerSettings.THE_NEW_STACK_FEED,
+        )
+
         soup = BeautifulSoup(response.text, "xml")
 
         items = soup.find_all("item")
@@ -74,6 +85,7 @@ class TheNewStackSpider(BaseSpider):
                 break
 
             item = self._build_item(raw_item)
+
             if item is not None:
                 collected.append(item)
 
@@ -112,12 +124,18 @@ class TheNewStackSpider(BaseSpider):
             return None
 
         categories = raw_item.find_all("category")
+
         tags = [c.get_text(strip=True) for c in categories]
 
         html_content = content_tag.get_text()
 
-        content_soup = BeautifulSoup(html_content, "html.parser")
+        content_soup = BeautifulSoup(
+            html_content,
+            "html.parser",
+        )
+
         paragraphs = content_soup.find_all("p")
+
         content = "\n".join(p.get_text(strip=True) for p in paragraphs)
 
         article = ArticleItem()

--- a/src/sri/crawler/spiders/theverge.py
+++ b/src/sri/crawler/spiders/theverge.py
@@ -19,6 +19,7 @@ from bs4 import BeautifulSoup
 # Local
 from sri.crawler.base import BaseSpider
 from sri.crawler.items import ArticleItem
+from sri.crawler.settings import CrawlerSettings
 
 
 class TheVergeSpider(BaseSpider):
@@ -32,14 +33,20 @@ class TheVergeSpider(BaseSpider):
         max_articles: Maximum number of articles to fetch in total.
     """
 
-    def __init__(self, max_articles: int = 500) -> None:
+    def __init__(
+        self,
+        max_articles: int = CrawlerSettings.MAX_ARTICLES,
+    ) -> None:
         """Initialise the spider with fetch limits.
 
         Args:
             max_articles: Maximum number of articles to fetch in total.
         """
         super().__init__(max_articles)
-        self._client = httpx.Client(timeout=10.0)
+
+        self._client = httpx.Client(
+            timeout=CrawlerSettings.HTTP_TIMEOUT,
+        )
 
     def fetch_articles(self) -> list[ArticleItem]:
         """Fetch and parse articles from The Verge Atom feed.
@@ -63,7 +70,10 @@ class TheVergeSpider(BaseSpider):
 
         collected: list[ArticleItem] = []
 
-        response = self._client.get("https://www.theverge.com/rss/index.xml")
+        response = self._client.get(
+            CrawlerSettings.THE_VERGE_FEED,
+        )
+
         soup = BeautifulSoup(response.text, "xml")
 
         entries = soup.find_all("entry")
@@ -73,6 +83,7 @@ class TheVergeSpider(BaseSpider):
                 break
 
             item = self._build_item(entry)
+
             if item is not None:
                 collected.append(item)
 
@@ -110,12 +121,15 @@ class TheVergeSpider(BaseSpider):
             return None
 
         categories = entry.find_all("category")
+
         tags = [cat.get("term", "") for cat in categories if cat.get("term")]
 
         html_content = content_tag.get_text()
 
         content_soup = BeautifulSoup(html_content, "html.parser")
+
         paragraphs = content_soup.find_all("p")
+
         content = "\n".join(p.get_text(strip=True) for p in paragraphs)
 
         article = ArticleItem()


### PR DESCRIPTION
## Summary
Introduce `CrawlerSettings` class in `src/sri/crawler/settings.py` as a single source of truth for all crawler configuration.

## Changes
- Added `CrawlerSettings` with HTTP timeout, fetch limits, API endpoints, RSS feeds, and search terms
- Updated all 6 spiders to import and use `CrawlerSettings` instead of inline literals
- `REALPYTHON_SITEMAP_URL` derived from `REALPYTHON_BASE_URL` (DRY)
- `LOBSTERS_BASE_URL` used to construct paginated URLs at runtime

## Tests
33/33 passing

Closes #26