### PR TITLE
Support declared DuckDuckGo search package

### DIFF
--- a/src/sri/web_search/searcher.py
+++ b/src/sri/web_search/searcher.py
@@ -10,7 +10,13 @@ from datetime import datetime, timezone
 # Third-party
 import httpx
 from bs4 import BeautifulSoup
-from ddgs import DDGS
+
+try:
+    from ddgs import DDGS
+except ModuleNotFoundError as exc:
+    if exc.name != "ddgs":
+        raise
+    from duckduckgo_search import DDGS
 
 
 class WebSearcher:

--- a/tests/sri/web_search/test_searcher_import.py
+++ b/tests/sri/web_search/test_searcher_import.py
@@ -1,0 +1,47 @@
+"""Import compatibility tests for WebSearcher."""
+
+# Standard library
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_searcher_imports_duckduckgo_search_when_ddgs_is_unavailable(tmp_path):
+    """Searcher should support the declared duckduckgo-search dependency."""
+    package_dir = tmp_path / "duckduckgo_search"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("class DDGS:\n    pass\n")
+    (tmp_path / "httpx.py").write_text("class HTTPError(Exception):\n    pass\n")
+    bs4_dir = tmp_path / "bs4"
+    bs4_dir.mkdir()
+    (bs4_dir / "__init__.py").write_text("class BeautifulSoup:\n    pass\n")
+
+    script = textwrap.dedent(
+        """
+        import importlib.util
+        import sys
+
+        sys.path = [path for path in sys.path if "site-packages" not in path]
+
+        spec = importlib.util.spec_from_file_location(
+            "searcher_under_test",
+            "src/sri/web_search/searcher.py",
+        )
+        searcher = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(searcher)
+
+        assert searcher.DDGS.__module__ == "duckduckgo_search"
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path)
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[3],
+        env=env,
+        check=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary
- fall back to `duckduckgo_search.DDGS` when the newer `ddgs` package is unavailable
- avoid swallowing unrelated `ModuleNotFoundError` exceptions from inside `ddgs`
- add an import compatibility regression test for the declared `duckduckgo-search` dependency

Closes #31

## Tests
- `python3 -m py_compile src/sri/web_search/searcher.py tests/sri/web_search/test_searcher_import.py`
- `python3 -m pytest tests/sri/web_search/test_searcher_import.py -q`

Note: `python3 -m pytest tests/sri/web_search/test_searcher.py -q` could not be collected in this environment because `httpx` is not installed and the system Python does not provide `pip`.