### PR TITLE
fix(web_search): replace ddgs import with duckduckgo_search

### DIFF
--- a/src/sri/web_search/searcher.py
+++ b/src/sri/web_search/searcher.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 # Third-party
 import httpx
 from bs4 import BeautifulSoup
-from ddgs import DDGS
+from duckduckgo_search import DDGS
 
 
 class WebSearcher:


### PR DESCRIPTION
## Problem

`searcher.py` imported from the non-existent `ddgs` module, causing `ModuleNotFoundError` on all imports of `sri.web_search`.

## Fix

Replace `from ddgs import DDGS` with `from duckduckgo_search import DDGS`, which is the correct package declared in `pyproject.toml`.

## Tests

13/13 web_search tests passing after fix.

Closes #31