### PR TITLE
fix(evaluation): fix tab nesting structure and add default test queries

### DIFF
--- a/data/test_queries.json
+++ b/data/test_queries.json
@@ -1,0 +1,74 @@
+{
+  "test_queries": [
+    {
+      "query_id": "q1",
+      "query": "what is docker and containerization",
+      "relevant": [
+        "2258ef56-c41c-4b27-b00e-52c661435fdf",
+        "4b6b137b-df26-4824-baf8-e71c72427493",
+        "55e82608-3aa0-4877-bbc4-1a534f727987"
+      ],
+      "grades": {
+        "2258ef56-c41c-4b27-b00e-52c661435fdf": 1,
+        "4b6b137b-df26-4824-baf8-e71c72427493": 1,
+        "55e82608-3aa0-4877-bbc4-1a534f727987": 1
+      }
+    },
+    {
+      "query_id": "q2",
+      "query": "python machine learning frameworks",
+      "relevant": [
+        "00f43711-0011-4161-b4fe-8226aec2dc1d",
+        "11247f0f-18c3-4234-9bf0-6c47f1bb3105",
+        "123eebd3-84c5-4530-afac-a82561de66e1"
+      ],
+      "grades": {
+        "00f43711-0011-4161-b4fe-8226aec2dc1d": 1,
+        "11247f0f-18c3-4234-9bf0-6c47f1bb3105": 1,
+        "123eebd3-84c5-4530-afac-a82561de66e1": 1
+      }
+    },
+    {
+      "query_id": "q3",
+      "query": "git version control workflow",
+      "relevant": [
+        "00f43711-0011-4161-b4fe-8226aec2dc1d",
+        "0c2fdc43-4643-4434-be86-9303e7de0bfa",
+        "0e4eff0e-4a59-4f73-83af-194f4784b53d"
+      ],
+      "grades": {
+        "00f43711-0011-4161-b4fe-8226aec2dc1d": 1,
+        "0c2fdc43-4643-4434-be86-9303e7de0bfa": 1,
+        "0e4eff0e-4a59-4f73-83af-194f4784b53d": 1
+      }
+    },
+    {
+      "query_id": "q4",
+      "query": "REST API design best practices",
+      "relevant": [
+        "00f43711-0011-4161-b4fe-8226aec2dc1d",
+        "0e4eff0e-4a59-4f73-83af-194f4784b53d",
+        "11247f0f-18c3-4234-9bf0-6c47f1bb3105"
+      ],
+      "grades": {
+        "00f43711-0011-4161-b4fe-8226aec2dc1d": 1,
+        "0e4eff0e-4a59-4f73-83af-194f4784b53d": 1,
+        "11247f0f-18c3-4234-9bf0-6c47f1bb3105": 1
+      }
+    },
+    {
+      "query_id": "q5",
+      "query": "RAG retrieval augmented generation",
+      "relevant": [
+        "00f43711-0011-4161-b4fe-8226aec2dc1d",
+        "0c2fdc43-4643-4434-be86-9303e7de0bfa",
+        "0e4eff0e-4a59-4f73-83af-194f4784b53d"
+      ],
+      "grades": {
+        "00f43711-0011-4161-b4fe-8226aec2dc1d": 1,
+        "0c2fdc43-4643-4434-be86-9303e7de0bfa": 1,
+        "0e4eff0e-4a59-4f73-83af-194f4784b53d": 1
+      }
+    }
+  ]
+}

--- a/ui/tabs/evaluation.py
+++ b/ui/tabs/evaluation.py
@@ -3,17 +3,15 @@
 from __future__ import annotations
 
 import json
-import gradio as gr
 from pathlib import Path
-from typing import Any
 
-from ..services.orchestrator_service import get_orchestrator_service
+import gradio as gr
+
 from ..components.charts import (
-    create_metrics_table,
-    create_per_query_table,
     render_evaluation_results_html,
-    try_plotly_metrics_chart
+    try_plotly_metrics_chart,
 )
+from ..services.orchestrator_service import get_orchestrator_service
 
 
 def build_evaluation_tab() -> None:
@@ -23,7 +21,7 @@ def build_evaluation_tab() -> None:
     Supports both default test loading and custom test design.
     """
     orchestrator_service = get_orchestrator_service()
-    
+
     gr.Markdown("## Evaluation System")
     gr.Markdown(
         "Design custom tests or run default benchmarks. "
@@ -38,7 +36,7 @@ def build_evaluation_tab() -> None:
         headers=["Query ID", "Query Text", "# Relevant", "Grade Scale"],
         label="Current Test Queries",
         interactive=False,
-        type="pandas"
+        type="pandas",
     )
     results_display = gr.HTML(label="Results")
 
@@ -47,18 +45,14 @@ def build_evaluation_tab() -> None:
         with gr.TabItem("Test Configuration"):
             gr.Markdown("### Select Test Mode")
 
-            test_mode = gr.Radio(
+            gr.Radio(
                 choices=["Load Default Test", "Design Custom Test"],
                 value="Load Default Test",
                 label="Test Mode",
-                info="Load existing test file or create custom tests"
+                info="Load existing test file or create custom tests",
             )
 
-            status_message = gr.Textbox(
-                label="Status",
-                interactive=False,
-                lines=2
-            )
+            status_message = gr.Textbox(label="Status", interactive=False, lines=2)
 
             with gr.Group():
                 gr.Markdown("### Quick Load")
@@ -68,10 +62,15 @@ def build_evaluation_tab() -> None:
                     """Load test queries from JSON file and return table data + simple HTML listing."""
                     test_file = Path("data/test_queries.json")
                     if not test_file.exists():
-                        return "[X] test_queries.json not found", [], [], "<p>test_queries.json not found</p>"
+                        return (
+                            "[X] test_queries.json not found",
+                            [],
+                            [],
+                            "<p>test_queries.json not found</p>",
+                        )
 
                     try:
-                        with open(test_file, "r", encoding="utf-8") as f:
+                        with open(test_file, encoding="utf-8") as f:
                             data = json.load(f)
                             tests = data.get("test_queries", [])
                             count = len(tests)
@@ -80,9 +79,11 @@ def build_evaluation_tab() -> None:
                             table_data = [
                                 [
                                     t.get("query_id", ""),
-                                    (t.get("query", "")[:40] + "...") if len(t.get("query", "")) > 40 else t.get("query", ""),
+                                    (t.get("query", "")[:40] + "...")
+                                    if len(t.get("query", "")) > 40
+                                    else t.get("query", ""),
                                     len(t.get("relevant", [])),
-                                    "Graded" if t.get("grades") else "Binary"
+                                    "Graded" if t.get("grades") else "Binary",
                                 ]
                                 for t in tests
                             ]
@@ -92,186 +93,206 @@ def build_evaluation_tab() -> None:
                             for t in tests:
                                 qid = t.get("query_id", "-")
                                 qtxt = t.get("query", "")
-                                results_html += f"<li><strong>{qid}</strong>: {qtxt}</li>"
+                                results_html += (
+                                    f"<li><strong>{qid}</strong>: {qtxt}</li>"
+                                )
                             results_html += "</ul></div>"
 
-                            return f"[OK] Loaded {count} test queries", tests, table_data, results_html
+                            return (
+                                f"[OK] Loaded {count} test queries",
+                                tests,
+                                table_data,
+                                results_html,
+                            )
                     except Exception as e:
-                        return f"[X] Error loading file: {str(e)}", [], [], "<p>Error loading tests</p>"
+                        return (
+                            f"[X] Error loading file: {str(e)}",
+                            [],
+                            [],
+                            "<p>Error loading tests</p>",
+                        )
 
                 load_default_btn.click(
                     load_default_tests,
-                    outputs=[status_message, test_queries_state, test_queries_display, results_display]
+                    outputs=[
+                        status_message,
+                        test_queries_state,
+                        test_queries_display,
+                        results_display,
+                    ],
                 )
 
-            # ===== Test Designer Tab =====
-            with gr.TabItem("Test Designer"):
-                gr.Markdown("### Create Custom Test Queries")
-                gr.Markdown(
-                    "Add queries and mark relevant documents. "
-                    "Optionally assign relevance grades (0-3 scale)."
+        # ===== Test Designer Tab =====
+        with gr.TabItem("Test Designer"):
+            gr.Markdown("### Create Custom Test Queries")
+            gr.Markdown(
+                "Add queries and mark relevant documents. "
+                "Optionally assign relevance grades (0-3 scale)."
+            )
+
+            with gr.Group():
+                gr.Markdown("#### Add Test Query")
+                query_id = gr.Textbox(placeholder="q1", label="Query ID")
+                query_text = gr.Textbox(
+                    placeholder="Enter search query", label="Query Text"
                 )
 
-                with gr.Group():
-                    gr.Markdown("#### Add Test Query")
-                    query_id = gr.Textbox(placeholder="q1", label="Query ID")
-                    query_text = gr.Textbox(placeholder="Enter search query", label="Query Text")
-                    
-                    grade_type = gr.Radio(
-                        choices=["Binary (Relevant/Not)", "Graded (0-3)"],
-                        value="Binary (Relevant/Not)",
-                        label="Relevance Scale"
-                    )
-                    
-                    relevant_docs = gr.Textbox(
-                        placeholder="doc_id1, doc_id2, doc_id3",
-                        label="Relevant Document IDs (comma-separated)",
-                        info="IDs of documents relevant to this query"
-                    )
-                    
-                    grades_input = gr.Textbox(
-                        placeholder="doc_id1:3, doc_id2:2",
-                        label="Grades (if graded scale selected)",
-                        info="Format: doc_id:grade, doc_id:grade (0=not relevant, 3=highly relevant)"
-                    )
-
-                    add_query_btn = gr.Button("➕ Add Query to Set", variant="secondary")
-                    
-                test_set_message = gr.Textbox(
-                    label="Test Set Status",
-                    interactive=False,
-                    lines=2
+                grade_type = gr.Radio(
+                    choices=["Binary (Relevant/Not)", "Graded (0-3)"],
+                    value="Binary (Relevant/Not)",
+                    label="Relevance Scale",
                 )
 
+                relevant_docs = gr.Textbox(
+                    placeholder="doc_id1, doc_id2, doc_id3",
+                    label="Relevant Document IDs (comma-separated)",
+                    info="IDs of documents relevant to this query",
+                )
 
-                def add_query_to_set(
-                    q_id: str,
-                    q_text: str,
-                    g_type: str,
-                    rel_docs: str,
-                    grades: str
-                ) -> tuple[str, list, list]:
-                    """Add a single query to test set."""
-                    if not q_id or not q_text or not rel_docs:
-                        return "[X] Query ID, text, and relevant docs are required", test_queries_state.value, []
+                grades_input = gr.Textbox(
+                    placeholder="doc_id1:3, doc_id2:2",
+                    label="Grades (if graded scale selected)",
+                    info="Format: doc_id:grade, doc_id:grade (0=not relevant, 3=highly relevant)",
+                )
 
-                    try:
-                        doc_list = [d.strip() for d in rel_docs.split(",")]
-                        
-                        query_entry = {
-                            "query_id": q_id.strip(),
-                            "query": q_text.strip(),
-                            "relevant": doc_list
-                        }
+                add_query_btn = gr.Button("➕ Add Query to Set", variant="secondary")
 
-                        if g_type == "Graded (0-3)" and grades:
-                            grade_dict = {}
-                            for pair in grades.split(","):
-                                doc_id, grade = pair.strip().split(":")
-                                grade_dict[doc_id.strip()] = int(grade.strip())
-                            query_entry["grades"] = grade_dict
+            test_set_message = gr.Textbox(
+                label="Test Set Status", interactive=False, lines=2
+            )
 
-                        current = test_queries_state.value or []
-                        current.append(query_entry)
+            def add_query_to_set(
+                q_id: str, q_text: str, g_type: str, rel_docs: str, grades: str
+            ) -> tuple[str, list, list]:
+                """Add a single query to test set."""
+                if not q_id or not q_text or not rel_docs:
+                    return (
+                        "[X] Query ID, text, and relevant docs are required",
+                        test_queries_state.value,
+                        [],
+                    )
 
-                        table_data = [
-                            [
-                                q["query_id"],
-                                (q["query"][:40] + "...") if len(q["query"]) > 40 else q["query"],
-                                len(q.get("relevant", [])),
-                                "Graded" if "grades" in q else "Binary"
-                            ]
-                            for q in current
+                try:
+                    doc_list = [d.strip() for d in rel_docs.split(",")]
+
+                    query_entry = {
+                        "query_id": q_id.strip(),
+                        "query": q_text.strip(),
+                        "relevant": doc_list,
+                    }
+
+                    if g_type == "Graded (0-3)" and grades:
+                        grade_dict = {}
+                        for pair in grades.split(","):
+                            doc_id, grade = pair.strip().split(":")
+                            grade_dict[doc_id.strip()] = int(grade.strip())
+                        query_entry["grades"] = grade_dict
+
+                    current = test_queries_state.value or []
+                    current.append(query_entry)
+
+                    table_data = [
+                        [
+                            q["query_id"],
+                            (q["query"][:40] + "...")
+                            if len(q["query"]) > 40
+                            else q["query"],
+                            len(q.get("relevant", [])),
+                            "Graded" if "grades" in q else "Binary",
                         ]
+                        for q in current
+                    ]
 
-                        return (
-                            f"[OK] Added query '{q_id}' to test set ({len(current)} total)",
-                            current,
-                            table_data
-                        )
-                    except Exception as e:
-                        return f"[X] Error: {str(e)}", test_queries_state.value, []
-
-                add_query_btn.click(
-                    add_query_to_set,
-                    inputs=[query_id, query_text, grade_type, relevant_docs, grades_input],
-                    outputs=[test_set_message, test_queries_state, test_queries_display]
-                )
-
-            # ===== Evaluation Execution Tab =====
-            with gr.TabItem("Run Evaluation"):
-                gr.Markdown("### Execute Evaluation")
-                
-                with gr.Group():
-                    execution_info = gr.Textbox(
-                        label="Test Set Info",
-                        interactive=False,
-                        lines=2
+                    return (
+                        f"[OK] Added query '{q_id}' to test set ({len(current)} total)",
+                        current,
+                        table_data,
                     )
-                    
-                    run_eval_btn = gr.Button("▶️  Run Evaluation", variant="primary", size="lg")
+                except Exception as e:
+                    return f"[X] Error: {str(e)}", test_queries_state.value, []
 
-                eval_progress = gr.Textbox(
-                    label="Progress",
-                    interactive=False,
-                    lines=2
+            add_query_btn.click(
+                add_query_to_set,
+                inputs=[query_id, query_text, grade_type, relevant_docs, grades_input],
+                outputs=[test_set_message, test_queries_state, test_queries_display],
+            )
+
+        # ===== Evaluation Execution Tab =====
+        with gr.TabItem("Run Evaluation"):
+            gr.Markdown("### Execute Evaluation")
+
+            with gr.Group():
+                execution_info = gr.Textbox(
+                    label="Test Set Info", interactive=False, lines=2
                 )
 
-                def get_test_info() -> str:
-                    """Get current test set information."""
-                    tests = test_queries_state.value
-                    if not tests:
-                        return "No test set loaded"
-                    return f"Test queries: {len(tests)}\nStatus: Ready to run"
+                run_eval_btn = gr.Button(
+                    "▶️  Run Evaluation", variant="primary", size="lg"
+                )
 
-                def run_evaluation() -> tuple[str]:
-                    """Execute evaluation on test set."""
-                    tests = test_queries_state.value
-                    if not tests:
-                        return ("[X] No test set loaded",)
+            eval_progress = gr.Textbox(label="Progress", interactive=False, lines=2)
 
-                    try:
-                        test_spec = {"test_queries": tests}
-                        result = orchestrator_service.evaluate_test(test_spec)
-                        
-                        if result.get("status") == "success":
-                            eval_progress_msg = (
-                                f"[OK] Evaluation completed\n"
-                                f"Queries evaluated: {result.get('aggregate', {}).get('num_queries', 0)}\n"
-                                f"Time: {result.get('execution_time_seconds', 0):.2f}s"
-                            )
-                            evaluation_result_state.value = result
-                            return (eval_progress_msg,)
-                        else:
-                            return (f"[X] Evaluation failed:\n{result.get('message', 'Unknown error')}",)
-                    except Exception as e:
-                        return (f"[X] Error: {str(e)}",)
+            def get_test_info() -> str:
+                """Get current test set information."""
+                tests = test_queries_state.value
+                if not tests:
+                    return "No test set loaded"
+                return f"Test queries: {len(tests)}\nStatus: Ready to run"
 
-                execution_info.value = get_test_info()
-                run_eval_btn.click(run_evaluation, outputs=[eval_progress])
+            def run_evaluation() -> tuple[str]:
+                """Execute evaluation on test set."""
+                tests = test_queries_state.value
+                if not tests:
+                    return ("[X] No test set loaded",)
 
-            # ===== Results Visualization Tab =====
-            with gr.TabItem("Results"):
-                gr.Markdown("### Evaluation Results")
+                try:
+                    test_spec = {"test_queries": tests}
+                    result = orchestrator_service.evaluate_test(test_spec)
 
-                def display_results() -> str:
-                    """Display evaluation results with visualization."""
-                    result = evaluation_result_state.value
-                    if not result or result.get("status") != "success":
-                        return "<p>No evaluation results available. Run evaluation first.</p>"
-
-                    aggregate = result.get("aggregate", {})
-                    per_query = result.get("per_query", [])
-                    exec_time = result.get("execution_time_seconds", 0)
-
-                    plotly_html = try_plotly_metrics_chart(result)
-                    if plotly_html:
-                        html_content = f"<h3>Metrics Visualization</h3>\n{plotly_html}"
+                    if result.get("status") == "success":
+                        eval_progress_msg = (
+                            f"[OK] Evaluation completed\n"
+                            f"Queries evaluated: {result.get('aggregate', {}).get('num_queries', 0)}\n"
+                            f"Time: {result.get('execution_time_seconds', 0):.2f}s"
+                        )
+                        evaluation_result_state.value = result
+                        return (eval_progress_msg,)
                     else:
-                        html_content = ""
+                        return (
+                            f"[X] Evaluation failed:\n{result.get('message', 'Unknown error')}",
+                        )
+                except Exception as e:
+                    return (f"[X] Error: {str(e)}",)
 
-                    html_content += "\n" + render_evaluation_results_html(aggregate, per_query, exec_time)
-                    return html_content
+            execution_info.value = get_test_info()
+            run_eval_btn.click(run_evaluation, outputs=[eval_progress])
 
-                display_results_btn = gr.Button("📊 Display Results")
-                display_results_btn.click(display_results, outputs=[results_display])
+        # ===== Results Visualization Tab =====
+        with gr.TabItem("Results"):
+            gr.Markdown("### Evaluation Results")
+
+            def display_results() -> str:
+                """Display evaluation results with visualization."""
+                result = evaluation_result_state.value
+                if not result or result.get("status") != "success":
+                    return (
+                        "<p>No evaluation results available. Run evaluation first.</p>"
+                    )
+
+                aggregate = result.get("aggregate", {})
+                per_query = result.get("per_query", [])
+                exec_time = result.get("execution_time_seconds", 0)
+
+                plotly_html = try_plotly_metrics_chart(result)
+                if plotly_html:
+                    html_content = f"<h3>Metrics Visualization</h3>\n{plotly_html}"
+                else:
+                    html_content = ""
+
+                html_content += "\n" + render_evaluation_results_html(
+                    aggregate, per_query, exec_time
+                )
+                return html_content
+
+            display_results_btn = gr.Button("📊 Display Results")
+            display_results_btn.click(display_results, outputs=[results_display])


### PR DESCRIPTION
## Problem

The Evaluation tab had two issues:

1. TabItems for Test Designer, Run Evaluation and Results were nested inside Test Configuration TabItem instead of the parent Tabs block — they never rendered as selectable tabs.
2. No `data/test_queries.json` existed, so Load Default Test always failed.

## Fix

- Corrected indentation so all 4 TabItems are at the same level inside `gr.Tabs()`
- Added `data/test_queries.json` with 5 domain-specific test queries with relevant document mappings
- Removed unused `test_mode` variable (ruff F841)

## Testing

- Manually verified all 4 tabs are visible and selectable in the UI
- Load Default Test button successfully loads 5 queries

Closes #35