### PR TITLE
fix(configuration): fix tab nesting, add RAG settings, and sync with Search

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -16,10 +16,10 @@ from .services.search_service import (
     map_progress_event,
 )
 from .state import UIState, create_default_state
-from .utils import validate_query
 from .tabs.configuration import build_configuration_tab
 from .tabs.evaluation import build_evaluation_tab
 from .tabs.status import build_status_tab
+from .utils import validate_query
 
 
 def _load_theme_css() -> str:
@@ -36,7 +36,9 @@ def _render_placeholder_results(state: UIState) -> tuple[str, str, str, str]:
         "This space will list documents, snippets, and metadata once retrieval is connected."
     )
     progress = "### Query progress\n\nNo query in progress."
-    rag_panel = "### RAG panel\n\nRAG output will appear here after retrieval completes."
+    rag_panel = (
+        "### RAG panel\n\nRAG output will appear here after retrieval completes."
+    )
     status_panel = format_search_status(
         {
             "minimum_documents": DEFAULT_MIN_DOCUMENTS,
@@ -51,7 +53,6 @@ def _render_placeholder_results(state: UIState) -> tuple[str, str, str, str]:
 
 def create_app() -> gr.Blocks:
     """Create the Gradio frontend shell."""
-    theme_css = _load_theme_css()
     state = create_default_state()
     orchestrator_service = get_orchestrator_service()
 
@@ -81,24 +82,6 @@ def create_app() -> gr.Blocks:
                             search_button = gr.Button("Search", variant="primary")
                             clear_button = gr.Button("Clear")
 
-                        with gr.Accordion("Search options", open=False):
-                            use_web_search = gr.Checkbox(value=True, label="Use web search")
-                            auto_reload = gr.Checkbox(value=True, label="Auto-reload database")
-                            max_local_results = gr.Slider(
-                                1,
-                                20,
-                                value=5,
-                                step=1,
-                                label="Max local results",
-                            )
-                            max_web_results = gr.Slider(
-                                0,
-                                20,
-                                value=10,
-                                step=1,
-                                label="Max web results",
-                            )
-
                         status_output = gr.Markdown(elem_classes=["ui-query-status"])
 
                     with gr.Column(scale=8, elem_classes=["ui-results-column"]):
@@ -107,19 +90,21 @@ def create_app() -> gr.Blocks:
                                 results_output = gr.Markdown()
                             with gr.Column(scale=4, elem_classes=["ui-rag-panel"]):
                                 rag_output = gr.Markdown()
-                        progress_output = gr.Markdown(elem_classes=["ui-progress-panel"])
+                        progress_output = gr.Markdown(
+                            elem_classes=["ui-progress-panel"]
+                        )
 
                 def run_search(
                     query: str,
-                    web_search_enabled: bool,
-                    auto_reload_enabled: bool,
-                    local_results: int,
-                    web_results: int,
                     session_state: UIState,
                 ):
-                    """Retrieve documents first and then generate the RAG response."""
+                    """Retrieve documents and generate RAG response using settings from state."""
                     progress_events: list[dict[str, str]] = []
 
+                    settings = session_state.settings
+                    web_search_enabled = settings.get("use_web_search", True)
+                    auto_reload_enabled = settings.get("auto_reload_empty", True)
+                    local_results = settings.get("max_local_results", 5)
                     is_valid, error_message = validate_query(query)
                     if not is_valid:
                         session_state.last_query = query or ""
@@ -142,14 +127,10 @@ def create_app() -> gr.Blocks:
                         return
 
                     session_state.last_query = query.strip()
-                    session_state.settings = {
-                        "use_web_search": web_search_enabled,
-                        "auto_reload_empty": auto_reload_enabled,
-                        "max_local_results": local_results,
-                        "max_web_results": web_results,
-                    }
                     retrieval_result: dict[str, object] = {}
-                    for retrieval_event in orchestrator_service.stream_retrieve_documents(
+                    for (
+                        retrieval_event
+                    ) in orchestrator_service.stream_retrieve_documents(
                         question=session_state.last_query,
                         max_local_results=local_results,
                         use_web_search=web_search_enabled,
@@ -163,7 +144,9 @@ def create_app() -> gr.Blocks:
                         if not progress_event:
                             continue
 
-                        if progress_events and progress_events[-1].get("stage") == progress_event.get("stage"):
+                        if progress_events and progress_events[-1].get(
+                            "stage"
+                        ) == progress_event.get("stage"):
                             progress_events[-1] = progress_event
                         else:
                             progress_events.append(progress_event)
@@ -172,7 +155,10 @@ def create_app() -> gr.Blocks:
                             "### Retrieval results\n\nCollecting documents...",
                             "### RAG panel\n\nWaiting for retrieval to finish.",
                             format_progress_panel(progress_events),
-                            format_search_status({"minimum_documents": DEFAULT_MIN_DOCUMENTS}, session_state.last_query),
+                            format_search_status(
+                                {"minimum_documents": DEFAULT_MIN_DOCUMENTS},
+                                session_state.last_query,
+                            ),
                             session_state,
                         )
 
@@ -191,7 +177,9 @@ def create_app() -> gr.Blocks:
                     if error_message:
                         session_state.retrieved_documents = []
                         session_state.rag_response = {}
-                        status_text = format_search_status(metadata, session_state.last_query)
+                        status_text = format_search_status(
+                            metadata, session_state.last_query
+                        )
                         progress_events.append(
                             {
                                 "stage": "retrieval_error",
@@ -212,7 +200,9 @@ def create_app() -> gr.Blocks:
                         doc for doc in documents if isinstance(doc, dict)
                     ]
                     results_text = format_search_results(documents, metadata)
-                    status_text = format_search_status(metadata, session_state.last_query)
+                    status_text = format_search_status(
+                        metadata, session_state.last_query
+                    )
 
                     loading_rag = (
                         "### RAG answer\n\n"
@@ -258,10 +248,14 @@ def create_app() -> gr.Blocks:
                         session_state,
                     )
 
-                def reset_search(session_state: UIState) -> tuple[str, str, str, str, str, UIState]:
+                def reset_search(
+                    session_state: UIState,
+                ) -> tuple[str, str, str, str, str, UIState]:
                     """Reset the search tab to its default empty state."""
                     default_state = create_default_state()
-                    results_text, progress_text, rag_text, status_text = _render_placeholder_results(default_state)
+                    results_text, progress_text, rag_text, status_text = (
+                        _render_placeholder_results(default_state)
+                    )
                     return (
                         "",
                         results_text,
@@ -273,30 +267,38 @@ def create_app() -> gr.Blocks:
 
                 search_button.click(
                     fn=run_search,
-                    inputs=[
-                        query_input,
-                        use_web_search,
-                        auto_reload,
-                        max_local_results,
-                        max_web_results,
+                    inputs=[query_input, app_state],
+                    outputs=[
+                        results_output,
+                        rag_output,
+                        progress_output,
+                        status_output,
                         app_state,
                     ],
-                    outputs=[results_output, rag_output, progress_output, status_output, app_state],
                 )
                 clear_button.click(
                     fn=reset_search,
                     inputs=[app_state],
-                    outputs=[query_input, results_output, progress_output, rag_output, status_output, app_state],
+                    outputs=[
+                        query_input,
+                        results_output,
+                        progress_output,
+                        rag_output,
+                        status_output,
+                        app_state,
+                    ],
                 )
 
-                default_results, default_progress, default_rag, default_status = _render_placeholder_results(state)
+                default_results, default_progress, default_rag, default_status = (
+                    _render_placeholder_results(state)
+                )
                 results_output.value = default_results
                 progress_output.value = default_progress
                 rag_output.value = default_rag
                 status_output.value = default_status
 
             with gr.Tab("Configuration"):
-                build_configuration_tab()
+                build_configuration_tab(app_state)
 
             with gr.Tab("Evaluation"):
                 build_evaluation_tab()

--- a/ui/tabs/configuration.py
+++ b/ui/tabs/configuration.py
@@ -8,12 +8,7 @@ from ..services.orchestrator_service import get_orchestrator_service
 
 
 def build_configuration_tab() -> None:
-    """
-    Build configuration management interface.
-
-    Handles system parameters, RAG settings, crawler configuration,
-    and database maintenance operations.
-    """
+    """Build configuration management interface."""
     orchestrator_service = get_orchestrator_service()
 
     gr.Markdown("## System Configuration")
@@ -22,7 +17,6 @@ def build_configuration_tab() -> None:
     )
 
     with gr.Tabs():
-        # ===== Query Parameters Tab =====
         with gr.TabItem("Query Parameters"):
             gr.Markdown("### Search Behavior")
             with gr.Group():
@@ -52,20 +46,11 @@ def build_configuration_tab() -> None:
                     label="Auto-reload Empty Database",
                     info="Automatically execute crawlers if index is below minimum",
                 )
-
             save_query_btn = gr.Button("💾 Save Query Settings", variant="primary")
             query_status = gr.Textbox(label="Status", interactive=False, visible=False)
 
-            def save_query_settings(
-                max_local: int, max_web: int, web_search: bool, auto_reload_db: bool
-            ) -> str:
-                """Save query settings (information only, not persisted)."""
-                return (
-                    f"[OK] Settings updated: "
-                    f"Local={max_local}, Web={max_web}, "
-                    f"WebSearch={'on' if web_search else 'off'}, "
-                    f"AutoReload={'on' if auto_reload_db else 'off'}"
-                )
+            def save_query_settings(max_local, max_web, web_search, auto_reload_db):
+                return f"[OK] Settings updated: Local={max_local}, Web={max_web}, WebSearch={'on' if web_search else 'off'}, AutoReload={'on' if auto_reload_db else 'off'}"
 
             save_query_btn.click(
                 save_query_settings,
@@ -78,206 +63,191 @@ def build_configuration_tab() -> None:
                 outputs=query_status,
             )
 
-            # ===== RAG Configuration Tab =====
         with gr.TabItem("RAG Configuration"):
             gr.Markdown("### Large Language Model Settings")
-        with gr.Group():
-            ollama_model = gr.Textbox(
-                value="llama3.2:latest",
-                label="Ollama Model",
-                info="Model identifier (e.g., llama3.2:latest)",
-                interactive=True,
-            )
-            ollama_url = gr.Textbox(
-                value="http://localhost:11434",
-                label="Ollama Base URL",
-                info="Full URL including protocol and port",
-                interactive=True,
-            )
-            gr.Slider(
-                minimum=0.0,
-                maximum=1.0,
-                value=0.7,
-                step=0.1,
-                label="Temperature",
-                info="Lower = more deterministic, Higher = more creative",
-                interactive=True,
-            )
-            gr.Slider(
-                minimum=100,
-                maximum=4096,
-                value=1024,
-                step=100,
-                label="Max Tokens",
-                info="Maximum length of generated response",
-                interactive=True,
-            )
-            gr.Slider(
-                minimum=1,
-                maximum=10,
-                value=5,
-                step=1,
-                label="Retrieval Top-K",
-                info="Documents used for RAG context",
-                interactive=True,
-            )
-
-        with gr.Group():
+            with gr.Group():
+                ollama_model = gr.Textbox(
+                    value="llama3.2:latest",
+                    label="Ollama Model",
+                    info="Model identifier (e.g., llama3.2:latest)",
+                    interactive=True,
+                )
+                ollama_url = gr.Textbox(
+                    value="http://localhost:11434",
+                    label="Ollama Base URL",
+                    info="Full URL including protocol and port",
+                    interactive=True,
+                )
+                gr.Slider(
+                    minimum=0.0,
+                    maximum=1.0,
+                    value=0.7,
+                    step=0.1,
+                    label="Temperature",
+                    info="Lower = more deterministic, Higher = more creative",
+                    interactive=True,
+                )
+                gr.Slider(
+                    minimum=100,
+                    maximum=4096,
+                    value=1024,
+                    step=100,
+                    label="Max Tokens",
+                    info="Maximum length of generated response",
+                    interactive=True,
+                )
+            gr.Markdown("### Response Settings")
+            with gr.Group():
+                gr.Slider(
+                    minimum=1,
+                    maximum=20,
+                    value=10,
+                    step=1,
+                    label="Max Citations in Response",
+                    info="Maximum source citations in the RAG answer (max_cites).",
+                    interactive=True,
+                )
+                gr.Slider(
+                    minimum=100,
+                    maximum=5000,
+                    value=1000,
+                    step=100,
+                    label="Max Document Context Length",
+                    info="Maximum characters per document injected into the RAG prompt (max_doc_content_length).",
+                    interactive=True,
+                )
             gr.Markdown("### Connection Test")
-            test_connection_btn = gr.Button(
-                "🔗 Test Ollama Connection", variant="secondary"
-            )
-            connection_status = gr.Textbox(
-                label="Connection Result", interactive=False, lines=3
-            )
+            with gr.Group():
+                test_connection_btn = gr.Button(
+                    "🔗 Test Ollama Connection", variant="secondary"
+                )
+                connection_status = gr.Textbox(
+                    label="Connection Result", interactive=False, lines=3
+                )
 
-        def test_ollama_connection(model: str, url: str) -> str:
-            """Test connection to Ollama service."""
-            try:
-                import requests
+            def test_ollama_connection(model, url):
+                try:
+                    import requests
 
-                response = requests.get(f"{url}/api/tags", timeout=5)
-                if response.status_code == 200:
-                    models = response.json().get("models", [])
-                    model_names = [m.get("name") for m in models]
-                    if model in model_names:
-                        return f"[OK] Connected to {url}\n[OK] Model '{model}' available\n[OK] Service healthy"
-                    else:
+                    response = requests.get(f"{url}/api/tags", timeout=5)
+                    if response.status_code == 200:
+                        models = response.json().get("models", [])
+                        model_names = [m.get("name") for m in models]
+                        if model in model_names:
+                            return f"[OK] Connected to {url}\n[OK] Model '{model}' available\n[OK] Service healthy"
                         return f"[OK] Connected but model '{model}' not found.\nAvailable: {', '.join(model_names[:3])}"
-                else:
                     return f"[X] Connection failed: HTTP {response.status_code}"
-            except requests.exceptions.ConnectionError:
-                return f"[X] Cannot connect to {url}. Is Ollama running?"
-            except Exception as e:
-                return f"[X] Error: {str(e)}"
+                except requests.exceptions.ConnectionError:
+                    return f"[X] Cannot connect to {url}. Is Ollama running?"
+                except Exception as e:
+                    return f"[X] Error: {str(e)}"
 
-        test_connection_btn.click(
-            test_ollama_connection,
-            inputs=[ollama_model, ollama_url],
-            outputs=connection_status,
-        )
+            test_connection_btn.click(
+                test_ollama_connection,
+                inputs=[ollama_model, ollama_url],
+                outputs=connection_status,
+            )
 
-        # ===== Crawler Configuration Tab =====
         with gr.TabItem("Crawler Configuration"):
             gr.Markdown("### Data Acquisition Settings")
-        with gr.Group():
-            gr.Slider(
-                minimum=100,
-                maximum=10000,
-                value=1000,
-                step=100,
-                label="Max Articles per Spider",
-                info="Maximum documents per crawler",
-                interactive=True,
-            )
-            gr.Slider(
-                minimum=30,
-                maximum=300,
-                value=120,
-                step=30,
-                label="Crawler Timeout (seconds)",
-                info="Maximum time per crawler execution",
-                interactive=True,
-            )
-            gr.Checkbox(
-                value=False,
-                label="Force Recrawl",
-                info="Ignore cached data and re-execute all crawlers",
-                interactive=True,
-            )
+            with gr.Group():
+                gr.Slider(
+                    minimum=100,
+                    maximum=10000,
+                    value=1000,
+                    step=100,
+                    label="Max Articles per Spider",
+                    info="Maximum documents per crawler",
+                    interactive=True,
+                )
+                gr.Slider(
+                    minimum=30,
+                    maximum=300,
+                    value=120,
+                    step=30,
+                    label="Crawler Timeout (seconds)",
+                    info="Maximum time per crawler execution",
+                    interactive=True,
+                )
+                gr.Checkbox(
+                    value=False,
+                    label="Force Recrawl",
+                    info="Ignore cached data and re-execute all crawlers",
+                    interactive=True,
+                )
 
-        # ===== Database Management Tab =====
         with gr.TabItem("Database Management"):
             gr.Markdown("### Database Operations")
-
-        with gr.Group():
-            gr.Markdown("#### Quick Actions")
-            col1, col2, col3 = gr.Row(), gr.Row(), gr.Row()
-
-            with col1:
-                clear_db_btn = gr.Button("🗑️  Clear All Data", variant="stop", scale=1)
-            with col2:
-                reindex_db_btn = gr.Button(
-                    "♻️  Reindex Database", variant="secondary", scale=1
-                )
-            with col3:
-                reload_db_btn = gr.Button(
-                    "📥 Reload from Crawlers", variant="secondary", scale=1
-                )
-
-        operation_output = gr.Textbox(
-            label="Operation Result", interactive=False, lines=4
-        )
-
-        gr.Markdown("#### Database Status")
-        db_info = gr.Textbox(label="Current Database Info", interactive=False, lines=5)
-
-        with gr.Group():
-            refresh_status_btn = gr.Button("🔄 Refresh Status")
-
-        def clear_database_with_confirmation() -> str:
-            """Clear all indices with confirmation."""
-            try:
-                result = orchestrator_service._get_orchestrator().clear_all_indices()
-                if result.get("success"):
-                    return f"[OK] Database cleared successfully\n{result.get('message', '')}"
-                else:
-                    return f"[X] Clear operation failed:\n{result.get('message', 'Unknown error')}"
-            except Exception as e:
-                return f"[X] Error: {str(e)}"
-
-        def reindex_database() -> str:
-            """Reindex database from available sources."""
-            try:
-                result = orchestrator_service._get_orchestrator().reindex_database()
-                if result.get("success"):
-                    return (
-                        f"[OK] Reindex completed\n"
-                        f"Indexed documents: {result.get('indexed_documents', 0)}\n"
-                        f"Duration: {result.get('duration_seconds', 0):.2f}s\n"
-                        f"{result.get('message', '')}"
+            with gr.Group():
+                gr.Markdown("#### Quick Actions")
+                col1, col2, col3 = gr.Row(), gr.Row(), gr.Row()
+                with col1:
+                    clear_db_btn = gr.Button(
+                        "🗑️  Clear All Data", variant="stop", scale=1
                     )
-                else:
+                with col2:
+                    reindex_db_btn = gr.Button(
+                        "♻️  Reindex Database", variant="secondary", scale=1
+                    )
+                with col3:
+                    reload_db_btn = gr.Button(
+                        "📥 Reload from Crawlers", variant="secondary", scale=1
+                    )
+            operation_output = gr.Textbox(
+                label="Operation Result", interactive=False, lines=4
+            )
+            gr.Markdown("#### Database Status")
+            db_info = gr.Textbox(
+                label="Current Database Info", interactive=False, lines=5
+            )
+            with gr.Group():
+                refresh_status_btn = gr.Button("🔄 Refresh Status")
+
+            def clear_database_with_confirmation():
+                try:
+                    result = (
+                        orchestrator_service._get_orchestrator().clear_all_indices()
+                    )
+                    if result.get("success"):
+                        return f"[OK] Database cleared successfully\n{result.get('message', '')}"
+                    return f"[X] Clear operation failed:\n{result.get('message', 'Unknown error')}"
+                except Exception as e:
+                    return f"[X] Error: {str(e)}"
+
+            def reindex_database():
+                try:
+                    result = orchestrator_service._get_orchestrator().reindex_database()
+                    if result.get("success"):
+                        return f"[OK] Reindex completed\nIndexed: {result.get('indexed_documents', 0)}\nDuration: {result.get('duration_seconds', 0):.2f}s"
                     return (
                         f"[X] Reindex failed:\n{result.get('message', 'Unknown error')}"
                     )
-            except Exception as e:
-                return f"[X] Error: {str(e)}"
+                except Exception as e:
+                    return f"[X] Error: {str(e)}"
 
-        def reload_from_crawlers() -> str:
-            """Execute full crawler pipeline."""
-            try:
-                result = orchestrator_service._get_orchestrator().load_documents_from_crawlers(
-                    max_articles=1000, force_recrawl=False
-                )
-                if result.get("success"):
-                    return (
-                        f"[OK] Crawlers executed successfully\n"
-                        f"Total documents: {result.get('total_documents', 0)}\n"
-                        f"Indexed: {result.get('indexed_documents', 0)}\n"
-                        f"Duration: {result.get('duration_seconds', 0):.2f}s"
+            def reload_from_crawlers():
+                try:
+                    result = orchestrator_service._get_orchestrator().load_documents_from_crawlers(
+                        max_articles=1000, force_recrawl=False
                     )
-                else:
+                    if result.get("success"):
+                        return f"[OK] Crawlers executed\nTotal: {result.get('total_documents', 0)}\nIndexed: {result.get('indexed_documents', 0)}\nDuration: {result.get('duration_seconds', 0):.2f}s"
                     return f"[X] Crawler execution failed:\n{result.get('message', 'Unknown error')}"
-            except Exception as e:
-                return f"[X] Error: {str(e)}"
+                except Exception as e:
+                    return f"[X] Error: {str(e)}"
 
-        def get_database_info() -> str:
-            """Get current database statistics."""
-            try:
-                health = (
-                    orchestrator_service._get_orchestrator().check_database_health()
-                )
-                return (
-                    f"Indexed documents: {health.get('document_count', 0)}\n"
-                    f"File documents: {health.get('file_document_count', 0)}\n"
-                    f"Status: {health.get('status', 'unknown')}\n"
-                    f"ChromaDB: {'[OK] Available' if health.get('has_chromadb') else '[X] Not available'}"
-                )
-            except Exception as e:
-                return f"[X] Error retrieving status: {str(e)}"
+            def get_database_info():
+                try:
+                    health = (
+                        orchestrator_service._get_orchestrator().check_database_health()
+                    )
+                    return f"Indexed documents: {health.get('document_count', 0)}\nFile documents: {health.get('file_document_count', 0)}\nStatus: {health.get('status', 'unknown')}\nChromaDB: {'[OK] Available' if health.get('has_chromadb') else '[X] Not available'}"
+                except Exception as e:
+                    return f"[X] Error retrieving status: {str(e)}"
 
-        clear_db_btn.click(clear_database_with_confirmation, outputs=operation_output)
-        reindex_db_btn.click(reindex_database, outputs=operation_output)
-        reload_db_btn.click(reload_from_crawlers, outputs=operation_output)
-        refresh_status_btn.click(get_database_info, outputs=db_info)
+            clear_db_btn.click(
+                clear_database_with_confirmation, outputs=operation_output
+            )
+            reindex_db_btn.click(reindex_database, outputs=operation_output)
+            reload_db_btn.click(reload_from_crawlers, outputs=operation_output)
+            refresh_status_btn.click(get_database_info, outputs=db_info)

--- a/ui/tabs/configuration.py
+++ b/ui/tabs/configuration.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import gradio as gr
-from typing import Any
 
 from ..services.orchestrator_service import get_orchestrator_service
-from ..config import DEFAULT_MIN_DOCUMENTS
 
 
 def build_configuration_tab() -> None:
@@ -34,7 +32,7 @@ def build_configuration_tab() -> None:
                     value=5,
                     step=1,
                     label="Max Local Results",
-                    info="Maximum results from local search"
+                    info="Maximum results from local search",
                 )
                 max_web_results = gr.Slider(
                     minimum=0,
@@ -42,31 +40,24 @@ def build_configuration_tab() -> None:
                     value=5,
                     step=1,
                     label="Max Web Results",
-                    info="Maximum external search results when insufficient"
+                    info="Maximum external search results when insufficient",
                 )
                 use_web_search = gr.Checkbox(
                     value=True,
                     label="Enable Web Search",
-                    info="Augment results with web search when local insufficient"
+                    info="Augment results with web search when local insufficient",
                 )
                 auto_reload = gr.Checkbox(
                     value=True,
                     label="Auto-reload Empty Database",
-                    info="Automatically execute crawlers if index is below minimum"
+                    info="Automatically execute crawlers if index is below minimum",
                 )
 
             save_query_btn = gr.Button("💾 Save Query Settings", variant="primary")
-            query_status = gr.Textbox(
-                label="Status",
-                interactive=False,
-                visible=False
-            )
+            query_status = gr.Textbox(label="Status", interactive=False, visible=False)
 
             def save_query_settings(
-                max_local: int,
-                max_web: int,
-                web_search: bool,
-                auto_reload_db: bool
+                max_local: int, max_web: int, web_search: bool, auto_reload_db: bool
             ) -> str:
                 """Save query settings (information only, not persisted)."""
                 return (
@@ -78,208 +69,215 @@ def build_configuration_tab() -> None:
 
             save_query_btn.click(
                 save_query_settings,
-                inputs=[max_local_results, max_web_results, use_web_search, auto_reload],
-                outputs=query_status
+                inputs=[
+                    max_local_results,
+                    max_web_results,
+                    use_web_search,
+                    auto_reload,
+                ],
+                outputs=query_status,
             )
 
             # ===== RAG Configuration Tab =====
-            with gr.TabItem("RAG Configuration"):
-                gr.Markdown("### Large Language Model Settings")
-            with gr.Group():
-                    ollama_model = gr.Textbox(
-                        value="llama3.2:latest",
-                        label="Ollama Model",
-                        info="Model identifier (e.g., llama3.2:latest)",
-                        interactive=True
-                    )
-                    ollama_url = gr.Textbox(
-                        value="http://localhost:11434",
-                        label="Ollama Base URL",
-                        info="Full URL including protocol and port",
-                        interactive=True
-                    )
-                    temperature = gr.Slider(
-                        minimum=0.0,
-                        maximum=1.0,
-                        value=0.7,
-                        step=0.1,
-                        label="Temperature",
-                        info="Lower = more deterministic, Higher = more creative",
-                        interactive=True
-                    )
-                    max_tokens = gr.Slider(
-                        minimum=100,
-                        maximum=4096,
-                        value=1024,
-                        step=100,
-                        label="Max Tokens",
-                        info="Maximum length of generated response",
-                        interactive=True
-                    )
-                    top_k_retrieval = gr.Slider(
-                        minimum=1,
-                        maximum=10,
-                        value=5,
-                        step=1,
-                        label="Retrieval Top-K",
-                        info="Documents used for RAG context",
-                        interactive=True
-                    )
+        with gr.TabItem("RAG Configuration"):
+            gr.Markdown("### Large Language Model Settings")
+        with gr.Group():
+            ollama_model = gr.Textbox(
+                value="llama3.2:latest",
+                label="Ollama Model",
+                info="Model identifier (e.g., llama3.2:latest)",
+                interactive=True,
+            )
+            ollama_url = gr.Textbox(
+                value="http://localhost:11434",
+                label="Ollama Base URL",
+                info="Full URL including protocol and port",
+                interactive=True,
+            )
+            gr.Slider(
+                minimum=0.0,
+                maximum=1.0,
+                value=0.7,
+                step=0.1,
+                label="Temperature",
+                info="Lower = more deterministic, Higher = more creative",
+                interactive=True,
+            )
+            gr.Slider(
+                minimum=100,
+                maximum=4096,
+                value=1024,
+                step=100,
+                label="Max Tokens",
+                info="Maximum length of generated response",
+                interactive=True,
+            )
+            gr.Slider(
+                minimum=1,
+                maximum=10,
+                value=5,
+                step=1,
+                label="Retrieval Top-K",
+                info="Documents used for RAG context",
+                interactive=True,
+            )
 
-            with gr.Group():
-                gr.Markdown("### Connection Test")
-                test_connection_btn = gr.Button("🔗 Test Ollama Connection", variant="secondary")
-                connection_status = gr.Textbox(
-                    label="Connection Result",
-                    interactive=False,
-                    lines=3
+        with gr.Group():
+            gr.Markdown("### Connection Test")
+            test_connection_btn = gr.Button(
+                "🔗 Test Ollama Connection", variant="secondary"
+            )
+            connection_status = gr.Textbox(
+                label="Connection Result", interactive=False, lines=3
+            )
+
+        def test_ollama_connection(model: str, url: str) -> str:
+            """Test connection to Ollama service."""
+            try:
+                import requests
+
+                response = requests.get(f"{url}/api/tags", timeout=5)
+                if response.status_code == 200:
+                    models = response.json().get("models", [])
+                    model_names = [m.get("name") for m in models]
+                    if model in model_names:
+                        return f"[OK] Connected to {url}\n[OK] Model '{model}' available\n[OK] Service healthy"
+                    else:
+                        return f"[OK] Connected but model '{model}' not found.\nAvailable: {', '.join(model_names[:3])}"
+                else:
+                    return f"[X] Connection failed: HTTP {response.status_code}"
+            except requests.exceptions.ConnectionError:
+                return f"[X] Cannot connect to {url}. Is Ollama running?"
+            except Exception as e:
+                return f"[X] Error: {str(e)}"
+
+        test_connection_btn.click(
+            test_ollama_connection,
+            inputs=[ollama_model, ollama_url],
+            outputs=connection_status,
+        )
+
+        # ===== Crawler Configuration Tab =====
+        with gr.TabItem("Crawler Configuration"):
+            gr.Markdown("### Data Acquisition Settings")
+        with gr.Group():
+            gr.Slider(
+                minimum=100,
+                maximum=10000,
+                value=1000,
+                step=100,
+                label="Max Articles per Spider",
+                info="Maximum documents per crawler",
+                interactive=True,
+            )
+            gr.Slider(
+                minimum=30,
+                maximum=300,
+                value=120,
+                step=30,
+                label="Crawler Timeout (seconds)",
+                info="Maximum time per crawler execution",
+                interactive=True,
+            )
+            gr.Checkbox(
+                value=False,
+                label="Force Recrawl",
+                info="Ignore cached data and re-execute all crawlers",
+                interactive=True,
+            )
+
+        # ===== Database Management Tab =====
+        with gr.TabItem("Database Management"):
+            gr.Markdown("### Database Operations")
+
+        with gr.Group():
+            gr.Markdown("#### Quick Actions")
+            col1, col2, col3 = gr.Row(), gr.Row(), gr.Row()
+
+            with col1:
+                clear_db_btn = gr.Button("🗑️  Clear All Data", variant="stop", scale=1)
+            with col2:
+                reindex_db_btn = gr.Button(
+                    "♻️  Reindex Database", variant="secondary", scale=1
+                )
+            with col3:
+                reload_db_btn = gr.Button(
+                    "📥 Reload from Crawlers", variant="secondary", scale=1
                 )
 
-            def test_ollama_connection(model: str, url: str) -> str:
-                """Test connection to Ollama service."""
-                try:
-                    import requests
-                    response = requests.get(f"{url}/api/tags", timeout=5)
-                    if response.status_code == 200:
-                        models = response.json().get('models', [])
-                        model_names = [m.get('name') for m in models]
-                        if model in model_names:
-                            return f"[OK] Connected to {url}\n[OK] Model '{model}' available\n[OK] Service healthy"
-                        else:
-                            return f"[OK] Connected but model '{model}' not found.\nAvailable: {', '.join(model_names[:3])}"
-                    else:
-                        return f"[X] Connection failed: HTTP {response.status_code}"
-                except requests.exceptions.ConnectionError:
-                    return f"[X] Cannot connect to {url}. Is Ollama running?"
-                except Exception as e:
-                    return f"[X] Error: {str(e)}"
+        operation_output = gr.Textbox(
+            label="Operation Result", interactive=False, lines=4
+        )
 
-            test_connection_btn.click(
-                test_ollama_connection,
-                inputs=[ollama_model, ollama_url],
-                outputs=connection_status
-            )
+        gr.Markdown("#### Database Status")
+        db_info = gr.Textbox(label="Current Database Info", interactive=False, lines=5)
 
-            # ===== Crawler Configuration Tab =====
-            with gr.TabItem("Crawler Configuration"):
-                gr.Markdown("### Data Acquisition Settings")
-            with gr.Group():
-                    max_articles = gr.Slider(
-                        minimum=100,
-                        maximum=10000,
-                        value=1000,
-                        step=100,
-                        label="Max Articles per Spider",
-                        info="Maximum documents per crawler",
-                        interactive=True
-                    )
-                    crawler_timeout = gr.Slider(
-                        minimum=30,
-                        maximum=300,
-                        value=120,
-                        step=30,
-                        label="Crawler Timeout (seconds)",
-                        info="Maximum time per crawler execution",
-                        interactive=True
-                    )
-                    force_recrawl = gr.Checkbox(
-                        value=False,
-                        label="Force Recrawl",
-                        info="Ignore cached data and re-execute all crawlers",
-                        interactive=True
-                    )
+        with gr.Group():
+            refresh_status_btn = gr.Button("🔄 Refresh Status")
 
-            # ===== Database Management Tab =====
-            with gr.TabItem("Database Management"):
-                gr.Markdown("### Database Operations")
+        def clear_database_with_confirmation() -> str:
+            """Clear all indices with confirmation."""
+            try:
+                result = orchestrator_service._get_orchestrator().clear_all_indices()
+                if result.get("success"):
+                    return f"[OK] Database cleared successfully\n{result.get('message', '')}"
+                else:
+                    return f"[X] Clear operation failed:\n{result.get('message', 'Unknown error')}"
+            except Exception as e:
+                return f"[X] Error: {str(e)}"
 
-            with gr.Group():
-                gr.Markdown("#### Quick Actions")
-                col1, col2, col3 = gr.Row(), gr.Row(), gr.Row()
-                
-                with col1:
-                    clear_db_btn = gr.Button("🗑️  Clear All Data", variant="stop", scale=1)
-                with col2:
-                    reindex_db_btn = gr.Button("♻️  Reindex Database", variant="secondary", scale=1)
-                with col3:
-                    reload_db_btn = gr.Button("📥 Reload from Crawlers", variant="secondary", scale=1)
-
-            operation_output = gr.Textbox(
-                label="Operation Result",
-                interactive=False,
-                lines=4
-            )
-
-            gr.Markdown("#### Database Status")
-            db_info = gr.Textbox(
-                label="Current Database Info",
-                interactive=False,
-                lines=5
-            )
-
-            with gr.Group():
-                refresh_status_btn = gr.Button("🔄 Refresh Status")
-
-            def clear_database_with_confirmation() -> str:
-                """Clear all indices with confirmation."""
-                try:
-                    result = orchestrator_service._get_orchestrator().clear_all_indices()
-                    if result.get('success'):
-                        return f"[OK] Database cleared successfully\n{result.get('message', '')}"
-                    else:
-                        return f"[X] Clear operation failed:\n{result.get('message', 'Unknown error')}"
-                except Exception as e:
-                    return f"[X] Error: {str(e)}"
-
-            def reindex_database() -> str:
-                """Reindex database from available sources."""
-                try:
-                    result = orchestrator_service._get_orchestrator().reindex_database()
-                    if result.get('success'):
-                        return (
-                            f"[OK] Reindex completed\n"
-                            f"Indexed documents: {result.get('indexed_documents', 0)}\n"
-                            f"Duration: {result.get('duration_seconds', 0):.2f}s\n"
-                            f"{result.get('message', '')}"
-                        )
-                    else:
-                        return f"[X] Reindex failed:\n{result.get('message', 'Unknown error')}"
-                except Exception as e:
-                    return f"[X] Error: {str(e)}"
-
-            def reload_from_crawlers() -> str:
-                """Execute full crawler pipeline."""
-                try:
-                    result = orchestrator_service._get_orchestrator().load_documents_from_crawlers(
-                        max_articles=1000,
-                        force_recrawl=False
-                    )
-                    if result.get('success'):
-                        return (
-                            f"[OK] Crawlers executed successfully\n"
-                            f"Total documents: {result.get('total_documents', 0)}\n"
-                            f"Indexed: {result.get('indexed_documents', 0)}\n"
-                            f"Duration: {result.get('duration_seconds', 0):.2f}s"
-                        )
-                    else:
-                        return f"[X] Crawler execution failed:\n{result.get('message', 'Unknown error')}"
-                except Exception as e:
-                    return f"[X] Error: {str(e)}"
-
-            def get_database_info() -> str:
-                """Get current database statistics."""
-                try:
-                    health = orchestrator_service._get_orchestrator().check_database_health()
+        def reindex_database() -> str:
+            """Reindex database from available sources."""
+            try:
+                result = orchestrator_service._get_orchestrator().reindex_database()
+                if result.get("success"):
                     return (
-                        f"Indexed documents: {health.get('document_count', 0)}\n"
-                        f"File documents: {health.get('file_document_count', 0)}\n"
-                        f"Status: {health.get('status', 'unknown')}\n"
-                        f"ChromaDB: {'[OK] Available' if health.get('has_chromadb') else '[X] Not available'}"
+                        f"[OK] Reindex completed\n"
+                        f"Indexed documents: {result.get('indexed_documents', 0)}\n"
+                        f"Duration: {result.get('duration_seconds', 0):.2f}s\n"
+                        f"{result.get('message', '')}"
                     )
-                except Exception as e:
-                    return f"[X] Error retrieving status: {str(e)}"
+                else:
+                    return (
+                        f"[X] Reindex failed:\n{result.get('message', 'Unknown error')}"
+                    )
+            except Exception as e:
+                return f"[X] Error: {str(e)}"
 
-            clear_db_btn.click(clear_database_with_confirmation, outputs=operation_output)
-            reindex_db_btn.click(reindex_database, outputs=operation_output)
-            reload_db_btn.click(reload_from_crawlers, outputs=operation_output)
-            refresh_status_btn.click(get_database_info, outputs=db_info)
+        def reload_from_crawlers() -> str:
+            """Execute full crawler pipeline."""
+            try:
+                result = orchestrator_service._get_orchestrator().load_documents_from_crawlers(
+                    max_articles=1000, force_recrawl=False
+                )
+                if result.get("success"):
+                    return (
+                        f"[OK] Crawlers executed successfully\n"
+                        f"Total documents: {result.get('total_documents', 0)}\n"
+                        f"Indexed: {result.get('indexed_documents', 0)}\n"
+                        f"Duration: {result.get('duration_seconds', 0):.2f}s"
+                    )
+                else:
+                    return f"[X] Crawler execution failed:\n{result.get('message', 'Unknown error')}"
+            except Exception as e:
+                return f"[X] Error: {str(e)}"
+
+        def get_database_info() -> str:
+            """Get current database statistics."""
+            try:
+                health = (
+                    orchestrator_service._get_orchestrator().check_database_health()
+                )
+                return (
+                    f"Indexed documents: {health.get('document_count', 0)}\n"
+                    f"File documents: {health.get('file_document_count', 0)}\n"
+                    f"Status: {health.get('status', 'unknown')}\n"
+                    f"ChromaDB: {'[OK] Available' if health.get('has_chromadb') else '[X] Not available'}"
+                )
+            except Exception as e:
+                return f"[X] Error retrieving status: {str(e)}"
+
+        clear_db_btn.click(clear_database_with_confirmation, outputs=operation_output)
+        reindex_db_btn.click(reindex_database, outputs=operation_output)
+        reload_db_btn.click(reload_from_crawlers, outputs=operation_output)
+        refresh_status_btn.click(get_database_info, outputs=db_info)

--- a/ui/tabs/configuration.py
+++ b/ui/tabs/configuration.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import gradio as gr
 
 from ..services.orchestrator_service import get_orchestrator_service
+from ..state import UIState
 
 
-def build_configuration_tab() -> None:
+def build_configuration_tab(app_state: gr.State) -> None:
     """Build configuration management interface."""
     orchestrator_service = get_orchestrator_service()
 
@@ -47,10 +48,29 @@ def build_configuration_tab() -> None:
                     info="Automatically execute crawlers if index is below minimum",
                 )
             save_query_btn = gr.Button("💾 Save Query Settings", variant="primary")
-            query_status = gr.Textbox(label="Status", interactive=False, visible=False)
+            query_status = gr.Textbox(label="Status", interactive=False, lines=1)
 
-            def save_query_settings(max_local, max_web, web_search, auto_reload_db):
-                return f"[OK] Settings updated: Local={max_local}, Web={max_web}, WebSearch={'on' if web_search else 'off'}, AutoReload={'on' if auto_reload_db else 'off'}"
+            def save_query_settings(
+                max_local: int,
+                max_web: int,
+                web_search: bool,
+                auto_reload_db: bool,
+                session_state: UIState,
+            ) -> tuple[str, UIState]:
+                """Persist query settings into session state for use by Search tab."""
+                session_state.settings = {
+                    "use_web_search": web_search,
+                    "auto_reload_empty": auto_reload_db,
+                    "max_local_results": max_local,
+                    "max_web_results": max_web,
+                }
+                status = (
+                    f"[OK] Settings saved — "
+                    f"Local={max_local}, Web={max_web}, "
+                    f"WebSearch={'on' if web_search else 'off'}, "
+                    f"AutoReload={'on' if auto_reload_db else 'off'}"
+                )
+                return status, session_state
 
             save_query_btn.click(
                 save_query_settings,
@@ -59,8 +79,9 @@ def build_configuration_tab() -> None:
                     max_web_results,
                     use_web_search,
                     auto_reload,
+                    app_state,
                 ],
-                outputs=query_status,
+                outputs=[query_status, app_state],
             )
 
         with gr.TabItem("RAG Configuration"):


### PR DESCRIPTION
## Problem

Three issues in the Configuration tab (Issue #37):

1. TabItems for RAG Configuration, Crawler Configuration and Database Management were nested inside Query Parameters TabItem.
2. Missing RAG settings: `max_cites` and `max_doc_content_length` not exposed in UI.
3. Search options accordion disconnected from Configuration settings.

## Fix

- Fixed nesting bug: all 4 TabItems now at correct indentation level
- Removed LSI Retrieval Depth slider — redundant with Max Local Results per team decision
- Added Max Citations in Response slider (max_cites, range 1-20)
- Added Max Document Context Length slider (max_doc_content_length, range 100-5000)
- Removed Search options accordion from Search tab
- run_search reads settings from session_state.settings
- build_configuration_tab receives app_state as parameter
- Save Query Settings persists settings to app_state for next search

## Testing

- All 4 tabs visible and selectable in Configuration
- Set Max Local Results=10, searched 'what is python', retrieved exactly 10 documents

Closes #37