### PR TITLE
fix(hackernews): clean HTML entities and tags from story_text

### DIFF
--- a/src/sri/crawler/spiders/hackernews.py
+++ b/src/sri/crawler/spiders/hackernews.py
@@ -8,6 +8,8 @@ API reference: http://hn.algolia.com/api/v1/search?tags=story&query=software
 
 import uuid
 
+from bs4 import BeautifulSoup
+
 from sri.crawler.base import ApiSpider
 from sri.crawler.items import ArticleItem
 from sri.crawler.settings import CrawlerSettings
@@ -101,8 +103,10 @@ class HackerNewsSpider(ApiSpider):
         article["title"] = raw_article.get("title", "")
         article["url"] = raw_article.get("url", "")
         article["date"] = raw_article.get("created_at", "")
-        article["content"] = raw_article.get("story_text") or raw_article.get(
-            "title", ""
+        raw_text = raw_article.get("story_text") or raw_article.get("title", "")
+        # Clean HTML tags and decode entities (e.g. &#x27; -> ')
+        article["content"] = BeautifulSoup(raw_text, "html.parser").get_text(
+            separator=" ", strip=True
         )
         article["source"] = "hackernews"
         article["tags"] = raw_article.get("_tags", [])

--- a/tests/sri/crawler/test_hackernews.py
+++ b/tests/sri/crawler/test_hackernews.py
@@ -52,3 +52,26 @@ def test_build_item_returns_article_item():
     assert result["content"] == "This is a test article."
     assert result["source"] == "hackernews"
     assert result["tags"] == ["software", "test"]
+
+
+def test_build_item_cleans_html_from_story_text():
+    """_build_item should decode HTML entities and strip tags from story_text."""
+    # Arrange
+    spider = HackerNewsSpider()
+    raw_article = {
+        "title": "Ask HN: How to handle software cracks?",
+        "url": "https://news.ycombinator.com/item?id=123",
+        "created_at": "2024-01-01T00:00:00Z",
+        "story_text": "We&#x27;ve found a crack.<p>It modifies our binaries &amp; bypasses activation.",
+        "_tags": ["story"],
+    }
+
+    # Act
+    result = spider._build_item(raw_article)
+
+    # Assert
+    assert result is not None
+    assert "&#x27;" not in result["content"], "HTML entities should be decoded"
+    assert "<p>" not in result["content"], "HTML tags should be stripped"
+    assert "We've" in result["content"], "Apostrophe should be decoded"
+    assert "&" in result["content"], "Ampersand entity should be decoded"


### PR DESCRIPTION
## Problem

The HackerNews Algolia API returns story_text as raw HTML with entities like `&#x27;` (apostrophe) and tags like `<p>`. This degrades LSI quality because HTML tokens inflate the vocabulary with noise.

## Fix

Apply BeautifulSoup to decode entities and strip tags in `_build_item`:
- `&#x27;` → `'`
- `<p>` → stripped
- `&amp;` → `&`

## Testing

- Existing 2 tests still pass
- New test added: `test_build_item_cleans_html_from_story_text`
- Verified against real corpus data (64 affected documents)

Closes #43